### PR TITLE
Fixes in translations

### DIFF
--- a/src/functionsdialog.cpp
+++ b/src/functionsdialog.cpp
@@ -267,6 +267,7 @@ void FunctionsDialog::deactivateClicked() {
 	if(f) {
 		f->setActive(!f->isActive());
 		functionsModel->invalidate();
+		updateFunctions();
 		emit itemsChanged();
 	}
 }

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -102,7 +102,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
 	statusDelayWidget = new QSpinBox(this);
 	statusDelayWidget->setRange(0, 10000);
 	statusDelayWidget->setSingleStep(250);
-	statusDelayWidget->setSuffix(tr(" ms"));
+	statusDelayWidget->setSuffix(" " + tr("ms"));
 	statusDelayWidget->setValue(settings->expression_status_delay); 
 	connect(statusDelayWidget, SIGNAL(valueChanged(int)), this, SLOT(statusDelayChanged(int)));
 	hbox->addWidget(statusDelayWidget);
@@ -226,7 +226,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
 	l2->addWidget(combo, r, 1); r++;
 	connect(combo, SIGNAL(currentIndexChanged(int)), this, SLOT(temperatureCalculationChanged(int)));
 	box = new QCheckBox(tr("Exchange rates updates:"), this); box->setChecked(settings->auto_update_exchange_rates > 0); connect(box, SIGNAL(toggled(bool)), this, SLOT(exratesToggled(bool))); l2->addWidget(box, r, 0);
-	QSpinBox *spin = new QSpinBox(this); spin->setRange(1, 100); spin->setSuffix(" " + tr("days")); spin->setValue(settings->auto_update_exchange_rates <= 0 ? 7 : settings->auto_update_exchange_rates); spin->setEnabled(settings->auto_update_exchange_rates > 0); connect(spin, SIGNAL(valueChanged(int)), this, SLOT(exratesChanged(int))); l2->addWidget(spin, r, 1); exratesSpin = spin; r++;
+	int days = settings->auto_update_exchange_rates <= 0 ? 7 : settings->auto_update_exchange_rates;
+	QSpinBox *spin = new QSpinBox(this); spin->setRange(1, 100); spin->setSuffix(" " + tr("days", "", days)); spin->setValue(days); spin->setEnabled(settings->auto_update_exchange_rates > 0); connect(spin, SIGNAL(valueChanged(int)), this, SLOT(exratesChanged(int))); l2->addWidget(spin, r, 1); exratesSpin = spin; r++;
+	connect(spin, QOverload<int>::of(&QSpinBox::valueChanged),[=](int i){spin->setSuffix(" " + tr("days", "", i));});
 	l2->setRowStretch(r, 1);
 	QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close);
 	topbox->addWidget(buttonBox);

--- a/src/unitsdialog.cpp
+++ b/src/unitsdialog.cpp
@@ -355,6 +355,7 @@ void UnitsDialog::deactivateClicked() {
 	if(u) {
 		u->setActive(!u->isActive());
 		unitsModel->invalidate();
+		updateUnits();
 		emit itemsChanged();
 	}
 }

--- a/src/variablesdialog.cpp
+++ b/src/variablesdialog.cpp
@@ -289,6 +289,7 @@ void VariablesDialog::deactivateClicked() {
 	if(v) {
 		v->setActive(!v->isActive());
 		variablesModel->invalidate();
+		updateVariables();
 		emit itemsChanged();
 	}
 }

--- a/translations/qalculate-qt_ru.ts
+++ b/translations/qalculate-qt_ru.ts
@@ -2,5237 +2,129 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru">
 <context>
-    <name></name>
-    <message>
-        <source>Qalculate!</source>
-        <translation type="vanished">Qalculate!</translation>
-    </message>
-    <message>
-        <source>Calculator</source>
-        <translation type="vanished">Калькулятор</translation>
-    </message>
-    <message>
-        <source>Powerful and easy to use calculator</source>
-        <translation type="vanished">Мощный и простой в использовании калькулятор</translation>
-    </message>
-    <message>
-        <source>calculation;arithmetic;scientific;financial;</source>
-        <translation type="vanished">расчёт;расчет;арифметика;научный;финансовый</translation>
-    </message>
-    <message>
-        <source>Qalculate! (Qt UI)</source>
-        <translation type="vanished">Qalculate! (Интерфейс Qt)</translation>
-    </message>
-    <message>
-        <source>Qalculate! is a multi-purpose cross-platform desktop calculator. It is simple to use but provides power and versatility normally reserved for complicated math packages, as well as useful tools for everyday needs (such as currency conversion and percent calculation).</source>
-        <translation type="vanished">Qalculate! - это универсальный кроссплатформенный настольный калькулятор. Он прост в использовании, но обеспечивает мощность и универсальность, обычно присущие сложным математическим программам, а также полезные инструменты для повседневных нужд (таких как конвертация валют и расчёт процентов).</translation>
-    </message>
-    <message>
-        <source>Features include a large library of customizable functions, unit calculations and conversion, physical constants, symbolic calculations (including integrals and equations), arbitrary precision, uncertainty propagation, interval arithmetic, plotting, and a user-friendly interface.</source>
-        <translation type="vanished">Возможности включают большую библиотеку настраиваемых функций, расчёт и преобразование единиц измерения, физические константы, символьные вычисления, включая интегралы и уравнения, произвольную точность, распространение неопределенности, интервальную арифметику, построение графиков и удобный интерфейс.</translation>
-    </message>
-    <message>
-        <source>Argument Rules</source>
-        <translation type="vanished">Правила для аргументов</translation>
-    </message>
-    <message>
-        <source>_Cancel</source>
-        <translation type="vanished">О_тмена</translation>
-    </message>
-    <message>
-        <source>Do not save modifications</source>
-        <translation type="vanished">Не сохранять изменения</translation>
-    </message>
-    <message>
-        <source>_OK</source>
-        <translation type="vanished">_OK</translation>
-    </message>
-    <message>
-        <source>Accept the modification of argument rules</source>
-        <translation type="vanished">Принять изменение правил для аргументов</translation>
-    </message>
-    <message>
-        <source>Enable rules and type test</source>
-        <translation type="vanished">Включить правила и проверку типа</translation>
-    </message>
-    <message>
-        <source>Custom condition</source>
-        <translation type="vanished">Условие</translation>
-    </message>
-    <message>
-        <source>For example if argument is a matrix that must have equal number of rows and columns: rows(\x) = columns(\x)</source>
-        <translation type="vanished">Например, если аргумент - это матрица, которая должна иметь равное количество строк и столбцов: строки(\x) = столбцы(\x)</translation>
-    </message>
-    <message>
-        <source>Allow matrix</source>
-        <translation type="vanished">Разрешить матрицы</translation>
-    </message>
-    <message>
-        <source>Forbid zero</source>
-        <translation type="vanished">Запретить ноль</translation>
-    </message>
-    <message>
-        <source>Handle vector</source>
-        <translation type="vanished">Обращаться с вектором</translation>
-    </message>
-    <message>
-        <source>Calculate function for each separate element in vector.</source>
-        <translation type="vanished">Вычислить функцию для каждого отдельного элемента вектора.</translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="vanished">Мин</translation>
-    </message>
-    <message>
-        <source>Include equals</source>
-        <translation type="vanished">Включая равенства</translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="vanished">Макс</translation>
-    </message>
-    <message>
-        <source>Keyboard Shortcuts</source>
-        <translation type="vanished">Клавиатурные комбинации</translation>
-    </message>
-    <message>
-        <source>_Close</source>
-        <translation type="vanished">В_ыход</translation>
-    </message>
-    <message>
-        <source>Label</source>
-        <translation type="vanished">Метка</translation>
-    </message>
-    <message>
-        <source>Left-click</source>
-        <translation type="vanished">Щелчок левой кнопкой</translation>
-    </message>
-    <message>
-        <source>Right-click</source>
-        <translation type="vanished">Щелчок правой кнопкой</translation>
-    </message>
-    <message>
-        <source>Middle-click</source>
-        <translation type="vanished">Щелчок средней кнопкой</translation>
-    </message>
-    <message>
-        <source>Reset</source>
-        <translation type="vanished">Сбросить</translation>
-    </message>
-    <message>
-        <source>Button Action</source>
-        <translation type="vanished">Действие клавиши</translation>
-    </message>
-    <message>
-        <source>Value</source>
-        <translation type="vanished">Значение</translation>
-    </message>
-    <message>
-        <source>Argument name</source>
-        <translation type="vanished">Имя аргумента</translation>
-    </message>
-    <message>
-        <source>Calendar Conversion</source>
-        <translation type="vanished">Преобразование календаря</translation>
-    </message>
-    <message>
-        <source>Export CSV File</source>
-        <translation type="vanished">Экспорт в файл типа CSV</translation>
-    </message>
-    <message>
-        <source>Current result</source>
-        <translation type="vanished">Текущий результат</translation>
-    </message>
-    <message>
-        <source>Matrix/vector variable</source>
-        <translation type="vanished">Матричная/векторная переменная</translation>
-    </message>
-    <message>
-        <source>File</source>
-        <translation type="vanished">Файл</translation>
-    </message>
-    <message>
-        <source>Delimiter</source>
-        <translation type="vanished">Разделитель</translation>
-    </message>
-    <message>
-        <source>Comma</source>
-        <translation type="vanished">Запятая</translation>
-    </message>
-    <message>
-        <source>Tabulator</source>
-        <translation type="vanished">Табуляция</translation>
-    </message>
-    <message>
-        <source>Semicolon</source>
-        <translation type="vanished">Точка с запятой</translation>
-    </message>
-    <message>
-        <source>Space</source>
-        <translation type="vanished">Пробел</translation>
-    </message>
-    <message>
-        <source>Other</source>
-        <translation type="vanished">Другой</translation>
-    </message>
-    <message>
-        <source>Import CSV File</source>
-        <translation type="vanished">Загрузить файл формата CSV</translation>
-    </message>
-    <message>
-        <source>Do not import the file</source>
-        <translation type="vanished">Не импортировать файл</translation>
-    </message>
-    <message>
-        <source>Import the file</source>
-        <translation type="vanished">Импортировать файл</translation>
-    </message>
-    <message>
-        <source>Name of the data file to import</source>
-        <translation type="vanished">Имя файла с данными для импорта</translation>
-    </message>
-    <message>
-        <source>Select a file</source>
-        <translation type="vanished">Выбрать файл</translation>
-    </message>
-    <message>
-        <source>Import as</source>
-        <translation type="vanished">Импортировать как</translation>
-    </message>
-    <message>
-        <source>Matrix</source>
-        <translation type="vanished">Матрица</translation>
-    </message>
-    <message>
-        <source>If a matrix shall be generated from the contents of the file</source>
-        <translation type="vanished">Если матрица должна быть создана из содержимого файла</translation>
-    </message>
-    <message>
-        <source>Vectors</source>
-        <translation type="vanished">Векторы</translation>
-    </message>
-    <message>
-        <source>If vectors shall be generated from the contents of the file</source>
-        <translation type="vanished">Если векторы должны быть созданы из содержимого файла</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="vanished">Имя</translation>
-    </message>
-    <message>
-        <source>Name (or name prefix) used to reference generated variable(s) in expressions</source>
-        <translation type="vanished">Имя (или префикс имени), используемое для ссылки на созданные переменные в выражениях</translation>
-    </message>
-    <message>
-        <source>Descriptive name</source>
-        <translation type="vanished">Кратное описание</translation>
-    </message>
-    <message>
-        <source>Title displayed in menus and in variable manager</source>
-        <translation type="vanished">Заголовок отображается в меню и в диспетчере переменных</translation>
-    </message>
-    <message>
-        <source>Category</source>
-        <translation type="vanished">Категория</translation>
-    </message>
-    <message>
-        <source>First row</source>
-        <translation type="vanished">Первая строка</translation>
-    </message>
-    <message>
-        <source>The first row with data to import in the file</source>
-        <translation type="vanished">Первая строка файла с данными для импорта</translation>
-    </message>
-    <message>
-        <source>Includes headings</source>
-        <translation type="vanished">Включает заголовки</translation>
-    </message>
-    <message>
-        <source>If the first row contains column headings</source>
-        <translation type="vanished">Если первая строка содержит заголовки столбцов</translation>
-    </message>
-    <message>
-        <source>Delimiter used to separate columns in the file</source>
-        <translation type="vanished">Разделитель, используемый для разделения столбцов в файле</translation>
-    </message>
-    <message>
-        <source>Custom delimiter</source>
-        <translation type="vanished">Пользовательский разделитель</translation>
-    </message>
-    <message>
-        <source>Edit Data Property</source>
-        <translation type="vanished">Изменить свойство данных</translation>
-    </message>
-    <message>
-        <source>Do not create/modify this data set</source>
-        <translation type="vanished">Не создавать/не изменять этот набор данных</translation>
-    </message>
-    <message>
-        <source>Accept the creation/modification of this data set</source>
-        <translation type="vanished">Принять создание/изменение этого набора данных</translation>
-    </message>
-    <message>
-        <source>Name used for reference</source>
-        <translation type="vanished">Имя, используемое для ссылки</translation>
-    </message>
-    <message>
-        <source>Properties</source>
-        <translation type="vanished">Свойства</translation>
-    </message>
-    <message>
-        <source>Title displayed in menus and in data set manager</source>
-        <translation type="vanished">Заголовок, отображаемый в меню и в диспетчере наборов данных</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation type="vanished">Расширенное описание</translation>
-    </message>
-    <message>
-        <source>Description of this data property</source>
-        <translation type="vanished">Описание этого свойства данных</translation>
-    </message>
-    <message>
-        <source>Value Type</source>
-        <translation type="vanished">Тип значения</translation>
-    </message>
-    <message>
-        <source>Text</source>
-        <translation type="vanished">Текст</translation>
-    </message>
-    <message>
-        <source>Number</source>
-        <translation type="vanished">Число</translation>
-    </message>
-    <message>
-        <source>Expression</source>
-        <translation type="vanished">Выражение</translation>
-    </message>
-    <message>
-        <source>Hide</source>
-        <translation type="vanished">Скрыть</translation>
-    </message>
-    <message>
-        <source>Use as key</source>
-        <translation type="vanished">Использовать как ключ</translation>
-    </message>
-    <message>
-        <source>Approximate value</source>
-        <translation type="vanished">Приближённое значение</translation>
-    </message>
-    <message>
-        <source>Case sensitive value</source>
-        <translation type="vanished">Значение с учётом регистра</translation>
-    </message>
-    <message>
-        <source>Value uses brackets</source>
-        <translation type="vanished">Значение использует скобки</translation>
-    </message>
-    <message>
-        <source>Unit expression</source>
-        <translation type="vanished">Выражение единицы измерения</translation>
-    </message>
-    <message>
-        <source>Edit Data Set</source>
-        <translation type="vanished">Изменить набор данных</translation>
-    </message>
-    <message>
-        <source>Title</source>
-        <translation type="vanished">Заголовок</translation>
-    </message>
-    <message>
-        <source>Data file</source>
-        <translation type="vanished">Файл данных</translation>
-    </message>
-    <message>
-        <source>Description of this data set</source>
-        <translation type="vanished">Описание этого набора данных</translation>
-    </message>
-    <message>
-        <source>Copyright</source>
-        <translation type="vanished">Авторские права</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Основное</translation>
-    </message>
-    <message>
-        <source>Properties:</source>
-        <translation type="vanished">Свойства:</translation>
-    </message>
-    <message>
-        <source>Definition of the properties of this data set</source>
-        <translation type="vanished">Определение свойств этого набора данных</translation>
-    </message>
-    <message>
-        <source>_New</source>
-        <translation type="vanished">_Новый</translation>
-    </message>
-    <message>
-        <source>_Edit</source>
-        <translation type="vanished">_Правка</translation>
-    </message>
-    <message>
-        <source>_Delete</source>
-        <translation type="vanished">_Удалить</translation>
-    </message>
-    <message>
-        <source>Name used to invoke the function in expressions</source>
-        <translation type="vanished">Имя, используемое для вызова функции в выражениях</translation>
-    </message>
-    <message>
-        <source>Object argument name</source>
-        <translation type="vanished">Имя аргумента объекта</translation>
-    </message>
-    <message>
-        <source>Property argument name</source>
-        <translation type="vanished">Имя аргумента свойства</translation>
-    </message>
-    <message>
-        <source>Default property</source>
-        <translation type="vanished">Свойство по умолчанию</translation>
-    </message>
-    <message>
-        <source>Function</source>
-        <translation type="vanished">Функция</translation>
-    </message>
-    <message>
-        <source>Edit Data Object</source>
-        <translation type="vanished">Изменить объект данных</translation>
-    </message>
-    <message>
-        <source>Do not create/modify this data object</source>
-        <translation type="vanished">Не создавать/не изменять этот объект данных</translation>
-    </message>
-    <message>
-        <source>Accept the creation/modification of this data object</source>
-        <translation type="vanished">Принять создание/изменение этого объекта данных</translation>
-    </message>
-    <message>
-        <source>Data Sets</source>
-        <extracomment>new dataset</extracomment>
-        <translation type="vanished">Наборы данных</translation>
-    </message>
-    <message>
-        <source>Data Set</source>
-        <translation type="vanished">Набор данных</translation>
-    </message>
-    <message>
-        <source>Create a new data set</source>
-        <translation type="vanished">Создать новый набор данных</translation>
-    </message>
-    <message>
-        <source>Edit the selected data set</source>
-        <translation type="vanished">Изменить выбранный набор данных</translation>
-    </message>
-    <message>
-        <source>Delete the selected data set</source>
-        <translation type="vanished">Удалить выбранный набор данных</translation>
-    </message>
-    <message>
-        <source>Objects</source>
-        <translation type="vanished">Объекты</translation>
-    </message>
-    <message>
-        <source>Create a new data object</source>
-        <translation type="vanished">Создать новый объект данных</translation>
-    </message>
-    <message>
-        <source>Edit the selected data object</source>
-        <translation type="vanished">Изменить выбранные данные объекта</translation>
-    </message>
-    <message>
-        <source>Remove the selected data object</source>
-        <translation type="vanished">Удалить выбранный объект данных</translation>
-    </message>
-    <message>
-        <source>Data Set Description</source>
-        <translation type="vanished">Описание набора данных</translation>
-    </message>
-    <message>
-        <source>Object Attributes</source>
-        <translation type="vanished">Атрибуты объекта</translation>
-    </message>
-    <message>
-        <source>Decimals</source>
-        <translation type="vanished">Десятичные дроби</translation>
-    </message>
-    <message>
-        <source>Close this window</source>
-        <translation type="vanished">Закрыть это окно</translation>
-    </message>
-    <message>
-        <source>Min decimals</source>
-        <translation type="vanished">Мин цифр</translation>
-    </message>
-    <message>
-        <source>Max decimals</source>
-        <translation type="vanished">Макс цифр</translation>
-    </message>
-    <message>
-        <source>Minimal number of displayed decimals</source>
-        <translation type="vanished">Минимальное количество отображаемых десятичных знаков</translation>
-    </message>
-    <message>
-        <source>Maximal number of decimals to display (and round to)</source>
-        <translation type="vanished">Максимальное количество отображаемых десятичных знаков</translation>
-    </message>
-    <message>
-        <source>Floating Point Conversion</source>
-        <translation type="vanished">Преобразование числа с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>Decimal value</source>
-        <translation type="vanished">Десятичное значение</translation>
-    </message>
-    <message>
-        <source>Binary value</source>
-        <translation type="vanished">Двоичное значение</translation>
-    </message>
-    <message>
-        <source>Octal value</source>
-        <translation type="vanished">Восьмеричное значение</translation>
-    </message>
-    <message>
-        <source>Hexadecimal representation</source>
-        <translation type="vanished">Шестнадцатеричное представление</translation>
-    </message>
-    <message>
-        <source>Conversion error</source>
-        <translation type="vanished">Ошибка преобразования</translation>
-    </message>
-    <message>
-        <source>Binary representation</source>
-        <translation type="vanished">Двоичное представление</translation>
-    </message>
-    <message>
-        <source>Floating point value</source>
-        <translation type="vanished">Значение числа с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>Format</source>
-        <translation type="vanished">Формат</translation>
-    </message>
-    <message>
-        <source>16-bit (half precision)</source>
-        <translation type="vanished">128-битное (половинная точность)</translation>
-    </message>
-    <message>
-        <source>32-bit (single precision)</source>
-        <translation type="vanished">32-битное (одинарная точность)</translation>
-    </message>
-    <message>
-        <source>64-bit (double precision)</source>
-        <translation type="vanished">64-битное (двойная точность)</translation>
-    </message>
-    <message>
-        <source>80-bit (x86 extended format)</source>
-        <translation type="vanished">80-битное (x86 расширенный формат)</translation>
-    </message>
-    <message>
-        <source>128-bit (quadruple precision)</source>
-        <translation type="vanished">128 -битное (четырехкратная точность)</translation>
-    </message>
-    <message>
-        <source>Hexadecimal value</source>
-        <translation type="vanished">Шестнадцатеричное значение</translation>
-    </message>
-    <message>
-        <source>Edit Function</source>
-        <translation type="vanished">Изменить функцию</translation>
-    </message>
-    <message>
-        <source>_Help</source>
-        <translation type="vanished">_Справка</translation>
-    </message>
-    <message>
-        <source>Do not create/modify this function</source>
-        <translation type="vanished">Не создавать/не изменять эту функцию</translation>
-    </message>
-    <message>
-        <source>Accept the creation/modification of this function</source>
-        <translation type="vanished">Принять создание/изменение этой функции</translation>
-    </message>
-    <message>
-        <source>Name used to invoke this function in expressions</source>
-        <translation type="vanished">Имя, используемое для вызова этой функции в выражениях</translation>
-    </message>
-    <message>
-        <source>Title displayed in menus and in function manager</source>
-        <translation type="vanished">Заголовок, отображаемый в меню и в диспетчере функций</translation>
-    </message>
-    <message>
-        <source>Hide function</source>
-        <translation type="vanished">Скрыть функцию</translation>
-    </message>
-    <message>
-        <source>If this function shall be hidden in menus</source>
-        <translation type="vanished">Если эта функция должна быть скрыта в меню</translation>
-    </message>
-    <message>
-        <source>Description of this function</source>
-        <translation type="vanished">Описание этой функции</translation>
-    </message>
-    <message>
-        <source>Use \x for the first, \y for the second and \z for the third argument. For more information click the help button.</source>
-        <translation type="vanished">Используйте \x для первого аргумента, \y для второго и \z для третьего.Для получения дополнительной информации нажмите кнопку справки.</translation>
-    </message>
-    <message>
-        <source>Condition</source>
-        <translation type="vanished">Условие</translation>
-    </message>
-    <message>
-        <source>Condition that must be true for the function (e.g. if the second argument must be greater than the first: &quot;\y &gt; \x&quot;)</source>
-        <translation type="vanished">Условие, которое должно выполняться для функции (например, если второй аргумент должен быть больше первого: «\y &gt; \x»)</translation>
-    </message>
-    <message>
-        <source>Sub-Functions</source>
-        <translation type="vanished">Подфункции</translation>
-    </message>
-    <message>
-        <source>Arguments:</source>
-        <translation type="vanished">Аргументы:</translation>
-    </message>
-    <message>
-        <source>Definition of this function&apos;s arguments</source>
-        <translation type="vanished">Определение аргументов этой функции</translation>
-    </message>
-    <message>
-        <source>Free</source>
-        <translation type="vanished">Произвольное значение</translation>
-    </message>
-    <message>
-        <source>Integer</source>
-        <translation type="vanished">Целое</translation>
-    </message>
-    <message>
-        <source>Symbol</source>
-        <translation type="vanished">Символ</translation>
-    </message>
-    <message>
-        <source>Date</source>
-        <translation type="vanished">Дата</translation>
-    </message>
-    <message>
-        <source>Vector</source>
-        <translation type="vanished">Вектор</translation>
-    </message>
-    <message>
-        <source>Positive number</source>
-        <translation type="vanished">Положительное число</translation>
-    </message>
-    <message>
-        <source>Non-zero number</source>
-        <translation type="vanished">Ненулевое число</translation>
-    </message>
-    <message>
-        <source>Non-negative number</source>
-        <translation type="vanished">Неотрицательное число</translation>
-    </message>
-    <message>
-        <source>Positive integer</source>
-        <translation type="vanished">Положительное целое</translation>
-    </message>
-    <message>
-        <source>Non-zero integer</source>
-        <translation type="vanished">Ненулевое целое</translation>
-    </message>
-    <message>
-        <source>Non-negative integer</source>
-        <translation type="vanished">Неотрицательное целое</translation>
-    </message>
-    <message>
-        <source>Boolean</source>
-        <translation type="vanished">Логическое</translation>
-    </message>
-    <message>
-        <source>Object</source>
-        <translation type="vanished">Объект</translation>
-    </message>
-    <message>
-        <source>Unit</source>
-        <translation type="vanished">Единица измерения</translation>
-    </message>
-    <message>
-        <source>Variable</source>
-        <translation type="vanished">Переменная</translation>
-    </message>
-    <message>
-        <source>Angle</source>
-        <translation type="vanished">Угол</translation>
-    </message>
-    <message>
-        <source>Data object</source>
-        <translation type="vanished">Объект данных</translation>
-    </message>
-    <message>
-        <source>Data property</source>
-        <translation type="vanished">Свойство данных</translation>
-    </message>
-    <message>
-        <source>_Add</source>
-        <translation type="vanished">_Добавить</translation>
-    </message>
-    <message>
-        <source>Add entered argument definition</source>
-        <translation type="vanished">Добавить введённое определение аргумента</translation>
-    </message>
-    <message>
-        <source>_Apply</source>
-        <translation type="vanished">П_рименить</translation>
-    </message>
-    <message>
-        <source>Modify selected argument</source>
-        <translation type="vanished">Изменить выбранный аргумент</translation>
-    </message>
-    <message>
-        <source>Remove selected argument</source>
-        <translation type="vanished">Удалить выбранный аргумент</translation>
-    </message>
-    <message>
-        <source>Rules</source>
-        <translation type="vanished">Правила</translation>
-    </message>
-    <message>
-        <source>Edit conditions for selected argument</source>
-        <translation type="vanished">Изменить условия для выбранного аргумента</translation>
-    </message>
-    <message>
-        <source>Close this dialog</source>
-        <translation type="vanished">Закройте это диалоговое окно</translation>
-    </message>
-    <message>
-        <source>Precalculate</source>
-        <translation type="vanished">Предварительно рассчитать</translation>
-    </message>
-    <message>
-        <source>Calculate the subfunction only once, before the parent function</source>
-        <translation type="vanished">Вычислить подфункцию только один раз, перед основной.</translation>
-    </message>
-    <message>
-        <source>Add entered subfunction</source>
-        <translation type="vanished">Добавить введённую подфункцию</translation>
-    </message>
-    <message>
-        <source>Apply changes to the selected subfunction</source>
-        <translation type="vanished">Применить изменения к выбранной подфункции</translation>
-    </message>
-    <message>
-        <source>Remove the selected subfunction</source>
-        <translation type="vanished">Удалить выбранную подфункцию</translation>
-    </message>
-    <message>
-        <source>Functions</source>
-        <translation type="vanished">Функции</translation>
-    </message>
-    <message>
-        <source>Create a new function</source>
-        <translation type="vanished">Создать новую функцию</translation>
-    </message>
-    <message>
-        <source>Edit the selected function</source>
-        <translation type="vanished">Изменить выбранную функцию</translation>
-    </message>
-    <message>
-        <source>_Insert</source>
-        <translation type="vanished">_Вставить</translation>
-    </message>
-    <message>
-        <source>Insert (or execute) the selected function into the expression entry</source>
-        <translation type="vanished">Вставить (или выполнить) выбранную функцию в выражение</translation>
-    </message>
-    <message>
-        <source>Delete the selected function</source>
-        <translation type="vanished">Удалить выбранную функцию</translation>
-    </message>
-    <message>
-        <source>(De)activate the selected function</source>
-        <translation type="vanished">(Де)активировать выбранную функцию</translation>
-    </message>
-    <message>
-        <source>Deacti_vate</source>
-        <translation type="vanished">_Деактивировать</translation>
-    </message>
-    <message>
-        <source>Apply the selected function to the current expression</source>
-        <translation type="vanished">Применить выбранную функцию к текущему выражению</translation>
-    </message>
-    <message>
-        <source>Categor_y</source>
-        <translation type="vanished">Категори_я</translation>
-    </message>
-    <message>
-        <source>_Function</source>
-        <translation type="vanished">_Функция</translation>
-    </message>
-    <message>
-        <source>Descri_ption</source>
-        <translation type="vanished">Описа_ние</translation>
-    </message>
-    <message>
-        <source>Degrees</source>
-        <translation type="vanished">Градусы</translation>
-    </message>
-    <message>
-        <source>Radians</source>
-        <translation type="vanished">Радианы</translation>
-    </message>
-    <message>
-        <source>Gradians</source>
-        <translation type="vanished">Грады</translation>
-    </message>
-    <message>
-        <source>Default assumptions</source>
-        <translation type="vanished">Предположения по умолчанию</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation type="vanished">Неизвестное</translation>
-    </message>
-    <message>
-        <source>Not Matrix</source>
-        <translation type="vanished">Не матрица</translation>
-    </message>
-    <message>
-        <source>Complex</source>
-        <translation type="vanished">Комплексное</translation>
-    </message>
-    <message>
-        <source>Real</source>
-        <translation type="vanished">Вещественное</translation>
-    </message>
-    <message>
-        <source>Rational</source>
-        <translation type="vanished">Рациональное</translation>
-    </message>
-    <message>
-        <source>Non-Zero</source>
-        <translation type="vanished">Ненулевое</translation>
-    </message>
-    <message>
-        <source>Positive</source>
-        <translation type="vanished">Положительное</translation>
-    </message>
-    <message>
-        <source>Non-Negative</source>
-        <translation type="vanished">Неотрицательное</translation>
-    </message>
-    <message>
-        <source>Negative</source>
-        <translation type="vanished">Отрицательное</translation>
-    </message>
-    <message>
-        <source>Non-Positive</source>
-        <translation type="vanished">Не положительное</translation>
-    </message>
-    <message>
-        <source>_File</source>
-        <translation type="vanished">_Файл</translation>
-    </message>
-    <message>
-        <source>Unknown Variable</source>
-        <translation type="vanished">Переменная неизвестного</translation>
-    </message>
-    <message>
-        <source>Function (simplified)</source>
-        <translation type="vanished">Функция (упрощённая)</translation>
-    </message>
-    <message>
-        <source>Import CSV File…</source>
-        <translation type="vanished">Загрузить CSV файл…</translation>
-    </message>
-    <message>
-        <source>Export CSV File…</source>
-        <translation type="vanished">Экспорт в CSV файл…</translation>
-    </message>
-    <message>
-        <source>_Store Result…</source>
-        <translation type="vanished">Со_хранить результат…</translation>
-    </message>
-    <message>
-        <source>Save Result Image…</source>
-        <translation type="vanished">Сохранить изображение с результатом…</translation>
-    </message>
-    <message>
-        <source>Save local functions, variables and units</source>
-        <translation type="vanished">Сохранить локальные функции, переменные и единицы измерения</translation>
-    </message>
-    <message>
-        <source>Save Definitions</source>
-        <translation type="vanished">Сохранить определения</translation>
-    </message>
-    <message>
-        <source>Import Definitions File…</source>
-        <translation type="vanished">Импортировать файл с определениями…</translation>
-    </message>
-    <message>
-        <source>Fetch current exchange rates from the Internet</source>
-        <translation type="vanished">Загрузить текущие курсы валют из Интернета.</translation>
-    </message>
-    <message>
-        <source>Update Exchange Rates</source>
-        <translation type="vanished">Обновить курсы валют</translation>
-    </message>
-    <message>
-        <source>Plot Functions/Data</source>
-        <translation type="vanished">Графики функций/данных</translation>
-    </message>
-    <message>
-        <source>Convert Number Bases</source>
-        <translation type="vanished">Преобразовать между основаниями систем счисления</translation>
-    </message>
-    <message>
-        <source>Floating Point Conversion (IEEE 754)</source>
-        <translation type="vanished">Преобразование чисел с плавающей запятой (IEEE 754)</translation>
-    </message>
-    <message>
-        <source>Percentage Calculation Tool</source>
-        <translation type="vanished">Инструмент расчёта процентов</translation>
-    </message>
-    <message>
-        <source>Periodic Table</source>
-        <translation type="vanished">Периодическая таблица</translation>
-    </message>
-    <message>
-        <source>Minimal Window</source>
-        <translation type="vanished">Минимальное окно</translation>
-    </message>
-    <message>
-        <source>_Quit</source>
-        <translation type="vanished">В_ыход</translation>
-    </message>
-    <message>
-        <source>Manage Variables</source>
-        <translation type="vanished">Управление переменными</translation>
-    </message>
-    <message>
-        <source>Manage Functions</source>
-        <translation type="vanished">Управление функциями</translation>
-    </message>
-    <message>
-        <source>Manage Units</source>
-        <translation type="vanished">Управление единицами измерения</translation>
-    </message>
-    <message>
-        <source>Manage Data Sets</source>
-        <translation type="vanished">Управление наборами данных</translation>
-    </message>
-    <message>
-        <source>Factorize</source>
-        <translation type="vanished">Разложить на множители</translation>
-    </message>
-    <message>
-        <source>Expand</source>
-        <translation type="vanished">Раскрывать</translation>
-    </message>
-    <message>
-        <source>Apply partial fraction decomposition to the current result.</source>
-        <translation type="vanished">Применить частичное дробное разложение к текущему результату.</translation>
-    </message>
-    <message>
-        <source>Expand Partial Fractions</source>
-        <translation type="vanished">Расширение дробных чисел</translation>
-    </message>
-    <message>
-        <source>Set Unknowns…</source>
-        <translation type="vanished">Установить неизвестные…</translation>
-    </message>
-    <message>
-        <source>Convert to Unit</source>
-        <translation type="vanished">Преобразовать к единице измерения</translation>
-    </message>
-    <message>
-        <source>Set Prefix</source>
-        <translation type="vanished">Установить префикс</translation>
-    </message>
-    <message>
-        <source>Convert to Unit Expression…</source>
-        <translation type="vanished">Преобразовать к выражению единиц измерения…</translation>
-    </message>
-    <message>
-        <source>Convert to Base Units</source>
-        <translation type="vanished">Преобразовать в базовые единицы измерения</translation>
-    </message>
-    <message>
-        <source>Convert to Optimal Unit</source>
-        <translation type="vanished">Преобразовать в оптимальные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Insert Date…</source>
-        <translation type="vanished">Вставить дату…</translation>
-    </message>
-    <message>
-        <source>Insert Matrix…</source>
-        <translation type="vanished">Вставить матрицу…</translation>
-    </message>
-    <message>
-        <source>Insert Vector…</source>
-        <translation type="vanished">Вставить вектор…</translation>
-    </message>
-    <message>
-        <source>_Copy Result</source>
-        <translation type="vanished">С_копировать результат</translation>
-    </message>
-    <message>
-        <source>Customize Keypad Buttons</source>
-        <translation type="vanished">Настроить кнопки клавиатуры</translation>
-    </message>
-    <message>
-        <source>_Preferences</source>
-        <translation type="vanished">_Параметры</translation>
-    </message>
-    <message>
-        <source>_Mode</source>
-        <translation type="vanished">_Режим</translation>
-    </message>
-    <message>
-        <source>Number Base</source>
-        <translation type="vanished">Основание системы счисления</translation>
-    </message>
-    <message>
-        <source>Select Result and Expression Base…</source>
-        <translation type="vanished">Выбрать основание системы счисления результата и выражения…</translation>
-    </message>
-    <message>
-        <source>Binary</source>
-        <translation type="vanished">Двоичное</translation>
-    </message>
-    <message>
-        <source>Octal</source>
-        <translation type="vanished">Восьмеричное</translation>
-    </message>
-    <message>
-        <source>Decimal</source>
-        <translation type="vanished">Десятичное</translation>
-    </message>
-    <message>
-        <source>Duodecimal</source>
-        <translation type="vanished">Двенадцатеричное</translation>
-    </message>
-    <message>
-        <source>Hexadecimal</source>
-        <translation type="vanished">Шестнадцатеричное</translation>
-    </message>
-    <message>
-        <source>Other…</source>
-        <translation type="vanished">Другое…</translation>
-    </message>
-    <message>
-        <source>Sexagesimal</source>
-        <translation type="vanished">Шестидесятеричное</translation>
-    </message>
-    <message>
-        <source>Time Format</source>
-        <translation type="vanished">Формат времени</translation>
-    </message>
-    <message>
-        <source>Roman Numerals</source>
-        <translation type="vanished">Римские цифры</translation>
-    </message>
-    <message>
-        <source>Numerical Display</source>
-        <translation type="vanished">Отображение чисел</translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="vanished">Обычное</translation>
-    </message>
-    <message>
-        <source>Engineering</source>
-        <translation type="vanished">Инженерное</translation>
-    </message>
-    <message>
-        <source>Scientific</source>
-        <translation type="vanished">Научное</translation>
-    </message>
-    <message>
-        <source>Purely Scientific</source>
-        <translation type="vanished">Простое научное</translation>
-    </message>
-    <message>
-        <source>Simple</source>
-        <translation type="vanished">Простое</translation>
-    </message>
-    <message>
-        <source>Off: 1/7 ≈ 0.14285714
-On: 1/7 = 0.142857 142857...</source>
-        <translation type="vanished">Выкл.: 1/7 ≈ 0,14285714
-Вкл.: 1/7 = 0.142857 142857...</translation>
-    </message>
-    <message>
-        <source>Indicate Repeating Decimals</source>
-        <translation type="vanished">Указывать повторяющиеся десятичные дроби</translation>
-    </message>
-    <message>
-        <source>Show Ending Zeroes</source>
-        <translation type="vanished">Показывать конечные нули</translation>
-    </message>
-    <message>
-        <source>Off: 2.5 ≈ 3,  1.5 ≈ 2
-On: 2.5 ≈ 2, 1.5 ≈ 2</source>
-        <translation type="vanished">Выкл.: 2,5 ≈ 3, 1,5 ≈ 2
-Вкл.: 2,5 ≈ 2, 1,5 ≈ 2</translation>
-    </message>
-    <message>
-        <source>Round Halfway Numbers to Even</source>
-        <translation type="vanished">Округлять половинные числа до ближайшего чётного целого числа.</translation>
-    </message>
-    <message>
-        <source>Off: -x + y
-On: y - x</source>
-        <translation type="vanished">Выкл.: -x + y
-Вкл.: y - x</translation>
-    </message>
-    <message>
-        <source>Sort Minus Last</source>
-        <translation type="vanished">Сортировать отрицательные последними</translation>
-    </message>
-    <message>
-        <source>Complex Rectangular Form</source>
-        <translation type="vanished">Прямоугольная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Complex Exponential Form</source>
-        <translation type="vanished">Экспоненциальная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Complex Polar Form</source>
-        <translation type="vanished">Полярная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Complex Angle/Phasor Notation</source>
-        <translation type="vanished">Обозначение угла/вектора комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Rational Number Form</source>
-        <translation type="vanished">Форма рационального числа</translation>
-    </message>
-    <message>
-        <source>1/3 ≈ 0.33333</source>
-        <translation type="vanished">1/3 ≈ 0,33333</translation>
-    </message>
-    <message>
-        <source>Decimal Fractions</source>
-        <translation type="vanished">Десятичные дроби</translation>
-    </message>
-    <message>
-        <source>3/9 = 1/3
-6/4 = 1.5</source>
-        <translation type="vanished">3/9 = 1/3
-6/4 = 1,5</translation>
-    </message>
-    <message>
-        <source>Exact Decimal Fractions</source>
-        <translation type="vanished">Точные десятичные дроби</translation>
-    </message>
-    <message>
-        <source>6/4 = 3/2</source>
-        <translation type="vanished">6/4 = 3/2</translation>
-    </message>
-    <message>
-        <source>Simple Fractions</source>
-        <translation type="vanished">Простые дроби</translation>
-    </message>
-    <message>
-        <source>6/4 = 1+1/2</source>
-        <translation type="vanished">6/4 = 1+1/2</translation>
-    </message>
-    <message>
-        <source>Mixed Fractions</source>
-        <translation type="vanished">Смешанные дроби</translation>
-    </message>
-    <message>
-        <source>Interval Display</source>
-        <translation type="vanished">Отображение интервалов</translation>
-    </message>
-    <message>
-        <source>Off: 1/2*pi ≈ 1.5707963
-On: 1/2*pi = 0.5 pi</source>
-        <translation type="vanished">Выкл.: 1/2*pi ≈ 1,5707963
-Вкл.: 1/2*pi = 0,5 pi</translation>
-    </message>
-    <message>
-        <source>Adaptive</source>
-        <translation type="vanished">Адаптивный</translation>
-    </message>
-    <message>
-        <source>Calculates an interval of possible values and keeps track of precision changes.</source>
-        <translation type="vanished">Рассчитывает интервал возможных значений и отслеживает точные изменения.</translation>
-    </message>
-    <message>
-        <source>Significant Digits</source>
-        <translation type="vanished">Значимые цифры</translation>
-    </message>
-    <message>
-        <source>Interval</source>
-        <translation type="vanished">Интервал</translation>
-    </message>
-    <message>
-        <source>Plus/Minus</source>
-        <translation type="vanished">Плюс/минус</translation>
-    </message>
-    <message>
-        <source>Midpoint</source>
-        <translation type="vanished">Середина</translation>
-    </message>
-    <message>
-        <source>Unit Display</source>
-        <translation type="vanished">Отображение единиц измерения</translation>
-    </message>
-    <message>
-        <source>Do not use any prefixes in result</source>
-        <translation type="vanished">Не использовать префиксы в результате</translation>
-    </message>
-    <message>
-        <source>Show prefixes for primarily SI and CGS units.</source>
-        <translation type="vanished">Показывать префиксы для преимущественно единиц измерения СИ и СГС.</translation>
-    </message>
-    <message>
-        <source>Use prefixes for selected units</source>
-        <translation type="vanished">Использовать префиксы для выбранных единиц измерения</translation>
-    </message>
-    <message>
-        <source>Use prefixes also for currencies</source>
-        <translation type="vanished">Использовать префиксы также для валют</translation>
-    </message>
-    <message>
-        <source>Use prefixs for all units</source>
-        <translation type="vanished">Использовать префиксы для всех единиц измерения</translation>
-    </message>
-    <message>
-        <source>Enables automatic use of hekto, deka, deci and centi when prefixes is enabled</source>
-        <translation type="vanished">Включает автоматическое использование гекто, дека, деци и санти, когда префиксы включены</translation>
-    </message>
-    <message>
-        <source>Enable All SI Prefixes</source>
-        <translation type="vanished">Включить все префиксы СИ</translation>
-    </message>
-    <message>
-        <source>Enables automatic setting of prefix for denominator in addition to the numerator</source>
-        <translation type="vanished">Включает автоматическую установку префикса для знаменателя в дополнение к числителю</translation>
-    </message>
-    <message>
-        <source>Enable Denominator Prefixes</source>
-        <translation type="vanished">Включить префиксы знаменателя</translation>
-    </message>
-    <message>
-        <source>Off: J / K
-On: J * K^-1</source>
-        <translation type="vanished">Выкл.: Дж / К
-Вкл.: Дж * К^-1</translation>
-    </message>
-    <message>
-        <source>Negative Exponents</source>
-        <translation type="vanished">Отрицательные степени</translation>
-    </message>
-    <message>
-        <source>Off: (2 m)/s
-On: 2 (m/s)</source>
-        <translation type="vanished">Выкл.: (2 м)/с
-Вкл.: 2 (м/с)</translation>
-    </message>
-    <message>
-        <source>Place Units Separately</source>
-        <translation type="vanished">Размещать единицы измерения отдельно</translation>
-    </message>
-    <message>
-        <source>No Additional Conversion</source>
-        <translation type="vanished">Без дополнительного преобразования</translation>
-    </message>
-    <message>
-        <source>Convert to Optimal SI Unit</source>
-        <translation type="vanished">Преобразовать в оптимальные единицы СИ</translation>
-    </message>
-    <message>
-        <source>If enabled:
-15 in = 1 ft + 3 in
-3.2 h = 3 h + 12 min</source>
-        <translation type="vanished">Если включено:
-15 дюймов = 1 фут + 3 дюйма
-3,2 ч = 3 ч + 12 мин</translation>
-    </message>
-    <message>
-        <source>Convert to Mixed Units</source>
-        <translation type="vanished">Преобразовать в смешанные единицы</translation>
-    </message>
-    <message>
-        <source>Abbreviate Names</source>
-        <translation type="vanished">Сокращённые имена</translation>
-    </message>
-    <message>
-        <source>Enabled Objects</source>
-        <translation type="vanished">Активные объекты</translation>
-    </message>
-    <message>
-        <source>Variables</source>
-        <translation type="vanished">Переменные</translation>
-    </message>
-    <message>
-        <source>Units</source>
-        <translation type="vanished">Единицы измерения</translation>
-    </message>
-    <message>
-        <source>Unknowns</source>
-        <translation type="vanished">Неизвестные</translation>
-    </message>
-    <message>
-        <source>Units in Physical Constants</source>
-        <translation type="vanished">Единицы измерения в физических константах</translation>
-    </message>
-    <message>
-        <source>If not enabled, treats all variables as unknown</source>
-        <translation type="vanished">Если не включено, все переменные рассматриваются как неизвестные.</translation>
-    </message>
-    <message>
-        <source>Calculate Variables</source>
-        <translation type="vanished">Вычислять переменные</translation>
-    </message>
-    <message>
-        <source>Disables/enables complex numbers in result</source>
-        <translation type="vanished">Запретить/разрешить комплексные числа в результате</translation>
-    </message>
-    <message>
-        <source>Allow Complex Result</source>
-        <translation type="vanished">Разрешить комплексный результат</translation>
-    </message>
-    <message>
-        <source>Disables/enables infinite numbers in result</source>
-        <translation type="vanished">Запретить/разрешить бесконечности в результате</translation>
-    </message>
-    <message>
-        <source>Allow Infinite Result</source>
-        <translation type="vanished">Разрешить бесконечный результат</translation>
-    </message>
-    <message>
-        <source>Approximation</source>
-        <translation type="vanished">Приближение</translation>
-    </message>
-    <message>
-        <source>Always Exact</source>
-        <translation type="vanished">Всегда точно</translation>
-    </message>
-    <message>
-        <source>Try Exact</source>
-        <translation type="vanished">Попробуй точно</translation>
-    </message>
-    <message>
-        <source>Approximate</source>
-        <translation type="vanished">Приблизительно</translation>
-    </message>
-    <message>
-        <source>Interval Arithmetic</source>
-        <translation type="vanished">Арифметика интервалов</translation>
-    </message>
-    <message>
-        <source>Interval Calculation</source>
-        <translation type="vanished">Расчёт интервала</translation>
-    </message>
-    <message>
-        <source>Variance Formula</source>
-        <translation type="vanished">Формула дисперсии</translation>
-    </message>
-    <message>
-        <source>Change angle unit used in trigonometric functions</source>
-        <translation type="vanished">Изменять единицы измерения углов, используемые в тригонометрических функциях</translation>
-    </message>
-    <message>
-        <source>Angle Unit</source>
-        <translation type="vanished">Единица измерения углов</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation type="vanished">Никакой</translation>
-    </message>
-    <message>
-        <source>Assumptions</source>
-        <translation type="vanished">Предположения</translation>
-    </message>
-    <message>
-        <source>Algebraic Mode</source>
-        <translation type="vanished">Алгебраический режим</translation>
-    </message>
-    <message>
-        <source>Assume that unknown denominators are non-zero</source>
-        <translation type="vanished">Предполагать, что знаменатели ненулевые</translation>
-    </message>
-    <message>
-        <source>Non-Zero Denominators</source>
-        <translation type="vanished">Не нулевые знаменатели</translation>
-    </message>
-    <message>
-        <source>Warn when unknown denominators are assumed non-zero</source>
-        <translation type="vanished">Предупреждать, когда неизвестные знаменатели предполагаются ненулевыми</translation>
-    </message>
-    <message>
-        <source>Warn About Denominators Assumed Non-Zero</source>
-        <translation type="vanished">Предупреждать о предположениях о  ненулевых знаменателях</translation>
-    </message>
-    <message>
-        <source>Parsing Mode</source>
-        <translation type="vanished">Режим анализа</translation>
-    </message>
-    <message>
-        <source>Adaptive Parsing</source>
-        <translation type="vanished">Адаптивный анализ</translation>
-    </message>
-    <message>
-        <source>Parse Implicit Multiplication First</source>
-        <translation type="vanished">Сначала анализировать неявное умножение</translation>
-    </message>
-    <message>
-        <source>Conventional Parsing</source>
-        <translation type="vanished">Общепринятый синтаксический анализ</translation>
-    </message>
-    <message>
-        <source>Chain Syntax</source>
-        <translation type="vanished">Цепной синтаксис</translation>
-    </message>
-    <message>
-        <source>RPN Syntax</source>
-        <translation type="vanished">синтаксис ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>Off: xy = x*y
-On: xy != x*y</source>
-        <translation type="vanished">Выкл.: xy = x*y
-Вкл.: xy != x*y</translation>
-    </message>
-    <message>
-        <source>Limit Implicit Multiplication</source>
-        <translation type="vanished">Ограничить неявное умножение</translation>
-    </message>
-    <message>
-        <source>Parse decimal numbers as approximate with precision equal to the number of digits.
-
-Off: 1.1 * 1.1 = 1.21
-On: 1.1 * 1.1 ≈ 1.2</source>
-        <translation type="vanished">Анализировать десятичные числа как приблизительные с точностью, равной количеству цифр.
-
-Выкл.: 1,1 * 1,1 = 1,21
-Вкл.: 1,1 * 1,1 ≈ 1,2</translation>
-    </message>
-    <message>
-        <source>Read Precision</source>
-        <translation type="vanished">Точность чтения</translation>
-    </message>
-    <message>
-        <source>_Precision</source>
-        <translation type="vanished">_Точность</translation>
-    </message>
-    <message>
-        <source>_Decimals</source>
-        <translation type="vanished">_Десятичные дроби</translation>
-    </message>
-    <message>
-        <source>Calculate As You Type</source>
-        <translation type="vanished">Расчёт по мере ввода</translation>
-    </message>
-    <message>
-        <source>Chain Mode</source>
-        <translation type="vanished">Режим «цепь»</translation>
-    </message>
-    <message>
-        <source>Activate the RPN stack.</source>
-        <translation type="vanished">Активировать стек ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>RPN Mode</source>
-        <translation type="vanished">Режим ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>Meta Modes</source>
-        <translation type="vanished">Мета-режимы</translation>
-    </message>
-    <message>
-        <source>Save Mode…</source>
-        <translation type="vanished">Сохранить режим…</translation>
-    </message>
-    <message>
-        <source>Delete Mode…</source>
-        <translation type="vanished">Удалить режим…</translation>
-    </message>
-    <message>
-        <source>Save Default _Mode</source>
-        <translation type="vanished">Сохранить как _режим по умолчанию</translation>
-    </message>
-    <message>
-        <source>Fu_nctions</source>
-        <translation type="vanished">Ф_ункции</translation>
-    </message>
-    <message>
-        <source>_Variables</source>
-        <translation type="vanished">_Переменные</translation>
-    </message>
-    <message>
-        <source>_Units</source>
-        <translation type="vanished">_Единицы</translation>
-    </message>
-    <message>
-        <source>_Contents</source>
-        <translation type="vanished">_Содержимое</translation>
-    </message>
-    <message>
-        <source>Report a Bug</source>
-        <translation type="vanished">Сообщить об ошибке</translation>
-    </message>
-    <message>
-        <source>Check for Updates</source>
-        <translation type="vanished">Проверить обновления</translation>
-    </message>
-    <message>
-        <source>_About</source>
-        <translation type="vanished">_О программе</translation>
-    </message>
-    <message>
-        <source>Toggle minimal window</source>
-        <translation type="vanished">Переключить в минимальное окно</translation>
-    </message>
-    <message>
-        <source>Calculation result</source>
-        <translation type="vanished">Результат расчёта</translation>
-    </message>
-    <message>
-        <source>_Keypad</source>
-        <translation type="vanished">_Клавиатура</translation>
-    </message>
-    <message>
-        <source>Toggles persistent keypad (makes it possible to show keypad and history simultaneously)</source>
-        <translation type="vanished">В(ы)ключает постоянную клавиатуру (позволяет одновременно отображать и клавиатуру, и историю)</translation>
-    </message>
-    <message>
-        <source>_History</source>
-        <translation type="vanished">_История</translation>
-    </message>
-    <message>
-        <source>C_onversion</source>
-        <translation type="vanished">_Преобразование</translation>
-    </message>
-    <message>
-        <source>RPN Stack</source>
-        <translation type="vanished">Стек ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>Insert the selected value</source>
-        <translation type="vanished">Вставить выбранное значение</translation>
-    </message>
-    <message>
-        <source>Insert the selected text</source>
-        <translation type="vanished">Вставить выбранный текст</translation>
-    </message>
-    <message>
-        <source>Copy the selected text</source>
-        <translation type="vanished">Копировать выбранный текст</translation>
-    </message>
-    <message>
-        <source>Add the selected value(s)</source>
-        <translation type="vanished">Добавить выбранное(ые) значение(я)</translation>
-    </message>
-    <message>
-        <source>Subtract the selected value(s)</source>
-        <translation type="vanished">Вычесть выбранное(ые) значение(я)</translation>
-    </message>
-    <message>
-        <source>Multiply the selected value(s)</source>
-        <translation type="vanished">Умножить выбранное(ые) значение(я)</translation>
-    </message>
-    <message>
-        <source>Divide the the selected value(s)</source>
-        <translation type="vanished">Разделить выбранное(ые) значение(я)</translation>
-    </message>
-    <message>
-        <source>Raise to the power of the selected value</source>
-        <translation type="vanished">Возвести в степень выбранное значение</translation>
-    </message>
-    <message>
-        <source>Calculate the square root of the selected value</source>
-        <translation type="vanished">Вычислить квадратный корень из выбранного значения</translation>
-    </message>
-    <message>
-        <source>History</source>
-        <translation type="vanished">История</translation>
-    </message>
-    <message>
-        <source>Subtract the top value from the second value</source>
-        <translation type="vanished">Вычитает верхнее значение из второго значения</translation>
-    </message>
-    <message>
-        <source>Multiply the top two values</source>
-        <translation type="vanished">Умножьте два значения в вершине</translation>
-    </message>
-    <message>
-        <source>Divide the second value by the top value</source>
-        <translation type="vanished">Разделите второе значение на значение в вершине</translation>
-    </message>
-    <message>
-        <source>Raise the second value to the power of the top value</source>
-        <translation type="vanished">Возвести второе значение в степень значения в вершине</translation>
-    </message>
-    <message>
-        <source>Negate the top value (Ctrl+-)</source>
-        <translation type="vanished">Изменить знак верхнего значение (Ctrl + -)</translation>
-    </message>
-    <message>
-        <source>Invert the top value</source>
-        <translation type="vanished">Инвертировать верхнее значение</translation>
-    </message>
-    <message>
-        <source>Calculate the square root of the top value</source>
-        <translation type="vanished">Вычислить квадратный корень из верхнего значения</translation>
-    </message>
-    <message>
-        <source>Calculate the sum of all values</source>
-        <translation type="vanished">Рассчитать сумму всех значений</translation>
-    </message>
-    <message>
-        <source>Rotate the stack or move selected register up</source>
-        <translation type="vanished">Повернуть стек или переместить выбранный регистр вверх</translation>
-    </message>
-    <message>
-        <source>Rotate the stack or move selected register down</source>
-        <translation type="vanished">Повернуть стек или переместить выбранный регистр вниз</translation>
-    </message>
-    <message>
-        <source>Swap the two top values or move the selected value to the top of the stack</source>
-        <translation type="vanished">Поменять местами два верхних значения или переместить выбранное значение в вершину стека.</translation>
-    </message>
-    <message>
-        <source>Copy the selected or top value to the top of the stack</source>
-        <translation type="vanished">Скопировать выбранное или верхнее значение в вершину стека</translation>
-    </message>
-    <message>
-        <source>Enter the top value from before the last numeric operation</source>
-        <translation type="vanished">Введите верхнее значение перед последней числовой операцией</translation>
-    </message>
-    <message>
-        <source>Delete the top or selected value</source>
-        <translation type="vanished">Удалить верхнее или выбранное значение</translation>
-    </message>
-    <message>
-        <source>Edit the selected value</source>
-        <translation type="vanished">Изменить выбранное значение</translation>
-    </message>
-    <message>
-        <source>Clear the RPN stack</source>
-        <translation type="vanished">Очистить стек ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>Unit(s) and prefix to convert result to</source>
-        <translation type="vanished">Единица(ы) измерения и префикс, к которым надо преобразовать результат</translation>
-    </message>
-    <message>
-        <source>Convert</source>
-        <translation type="vanished">Перевести</translation>
-    </message>
-    <message>
-        <source>Continuous conversion</source>
-        <translation type="vanished">Непрерывное преобразование</translation>
-    </message>
-    <message>
-        <source>Automatically convert result to the current unit expression as long as the conversion box is visible.</source>
-        <translation type="vanished">Автоматически преобразовывать результат в текущее выражение единицы измерения, пока отображается поле преобразования.</translation>
-    </message>
-    <message>
-        <source>Add prefix</source>
-        <translation type="vanished">Добавить префикс</translation>
-    </message>
-    <message>
-        <source>If unit expression does not contain any prefixes, use optimal prefix. 
-
-This can be overridden by prepending the unit expression with &quot;?&quot; or &quot;0&quot;.</source>
-        <translation type="vanished">Если выражение единицы измерения не содержит префиксов, использовать оптимальный префикс.
-
-Это можно изменить, добавив к выражению единицы измерения «?» или «0».</translation>
-    </message>
-    <message>
-        <source>Conversion</source>
-        <translation type="vanished">Преобразование</translation>
-    </message>
-    <message>
-        <source>Show/hide programming keypad</source>
-        <translation type="vanished">Показать/скрыть клавиатуру программирования</translation>
-    </message>
-    <message>
-        <source>Exact</source>
-        <translation type="vanished">Точно</translation>
-    </message>
-    <message>
-        <source>Fraction</source>
-        <translation type="vanished">Дробь</translation>
-    </message>
-    <message>
-        <source>Numerical display</source>
-        <translation type="vanished">Отображение чисел</translation>
-    </message>
-    <message>
-        <source>Pure</source>
-        <translation type="vanished">Упрощённое научное</translation>
-    </message>
-    <message>
-        <source>Number base</source>
-        <translation type="vanished">Основание системы счисления</translation>
-    </message>
-    <message>
-        <source>Time format</source>
-        <translation type="vanished">Формат времени</translation>
-    </message>
-    <message>
-        <source>Roman</source>
-        <translation type="vanished">Римские</translation>
-    </message>
-    <message>
-        <source>sin</source>
-        <translation type="vanished">sin</translation>
-    </message>
-    <message>
-        <source>cos</source>
-        <translation type="vanished">cos</translation>
-    </message>
-    <message>
-        <source>tan</source>
-        <translation type="vanished">tg</translation>
-    </message>
-    <message>
-        <source>ln</source>
-        <translation type="vanished">ln</translation>
-    </message>
-    <message>
-        <source>Equals</source>
-        <translation type="vanished">Равенства</translation>
-    </message>
-    <message>
-        <source>sqrt</source>
-        <translation type="vanished">√</translation>
-    </message>
-    <message>
-        <source>sum</source>
-        <translation type="vanished">∑</translation>
-    </message>
-    <message>
-        <source>Unknown variable</source>
-        <translation type="vanished">Переменная неизвестного</translation>
-    </message>
-    <message>
-        <source>mod</source>
-        <translation type="vanished">mod</translation>
-    </message>
-    <message>
-        <source>mean</source>
-        <translation type="vanished">Среднее</translation>
-    </message>
-    <message>
-        <source>Store result as a variable</source>
-        <translation type="vanished">Сохранить результат как переменную</translation>
-    </message>
-    <message>
-        <source>STO</source>
-        <extracomment>Standard calculator button. Do not use more than three characters.</extracomment>
-        <translation type="vanished">СХР</translation>
-    </message>
-    <message>
-        <source>Convert number bases</source>
-        <translation type="vanished">Преобразование между основаниями систем счисления</translation>
-    </message>
-    <message>
-        <source>Imaginary unit i (√-1)</source>
-        <translation type="vanished">Мнимая единица i (√-1)</translation>
-    </message>
-    <message>
-        <source>Manage units</source>
-        <translation type="vanished">Управление единицами измерения</translation>
-    </message>
-    <message>
-        <source>Conversion operator</source>
-        <translation type="vanished">Оператор преобразования</translation>
-    </message>
-    <message>
-        <source>Kilogram</source>
-        <translation type="vanished">Килограмм</translation>
-    </message>
-    <message>
-        <source>Two&apos;s complement input</source>
-        <translation type="vanished">Дополнительный код для ввода</translation>
-    </message>
-    <message>
-        <source>Two&apos;s complement output</source>
-        <translation type="vanished">Дополнительный код для вывода</translation>
-    </message>
-    <message>
-        <source>Bitwise Exclusive OR</source>
-        <translation type="vanished">Побитовое исключающее ИЛИ</translation>
-    </message>
-    <message>
-        <source>Bitwise Left Shift</source>
-        <translation type="vanished">Побитовый сдвиг влево</translation>
-    </message>
-    <message>
-        <source>Bitwise Right Shift</source>
-        <translation type="vanished">Побитовый сдвиг вправо</translation>
-    </message>
-    <message>
-        <source>Floating point conversion</source>
-        <translation type="vanished">Преобразование числа с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>Show/hide left keypad</source>
-        <translation type="vanished">Показать/скрыть левую клавиатуру</translation>
-    </message>
-    <message>
-        <source>Show/hide right keypad</source>
-        <translation type="vanished">Показать/скрыть правую клавиатуру</translation>
-    </message>
-    <message>
-        <source>DEL</source>
-        <extracomment>Standard calculator button. Do not use more than three characters.</extracomment>
-        <translation type="vanished">←</translation>
-    </message>
-    <message>
-        <source>AC</source>
-        <extracomment>Standard calculator button. Do not use more than three characters.</extracomment>
-        <translation type="vanished">С</translation>
-    </message>
-    <message>
-        <source>Previous result</source>
-        <translation type="vanished">Предыдущий результат</translation>
-    </message>
-    <message>
-        <source>ANS</source>
-        <extracomment>Standard calculator button. Do not use more than three characters.</extracomment>
-        <translation type="vanished">ОТВ</translation>
-    </message>
-    <message>
-        <source>EXP</source>
-        <translation type="vanished">EXP</translation>
-    </message>
-    <message>
-        <source>Add to Expression</source>
-        <translation type="vanished">Добавить в выражение</translation>
-    </message>
-    <message>
-        <source>Persistent Keypad</source>
-        <translation type="vanished">Постоянная клавиатура</translation>
-    </message>
-    <message>
-        <source>Edit</source>
-        <translation type="vanished">Правка</translation>
-    </message>
-    <message>
-        <source>Delete</source>
-        <translation type="vanished">Удалить</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Обновить</translation>
-    </message>
-    <message>
-        <source>Insert Value</source>
-        <translation type="vanished">Вставить значение</translation>
-    </message>
-    <message>
-        <source>Insert Text</source>
-        <translation type="vanished">Вставить текст</translation>
-    </message>
-    <message>
-        <source>Insert Parsed Text</source>
-        <translation type="vanished">Вставить проанализированный текст</translation>
-    </message>
-    <message>
-        <source>Copy</source>
-        <translation type="vanished">Копировать</translation>
-    </message>
-    <message>
-        <source>Copy Full Text</source>
-        <translation type="vanished">Копировать полный текст</translation>
-    </message>
-    <message>
-        <source>Search…</source>
-        <translation type="vanished">Поиск…</translation>
-    </message>
-    <message>
-        <source>Add Bookmark…</source>
-        <translation type="vanished">Добавить закладку…</translation>
-    </message>
-    <message>
-        <source>Bookmarks</source>
-        <translation type="vanished">Закладки</translation>
-    </message>
-    <message>
-        <source>Protect</source>
-        <translation type="vanished">Защитить</translation>
-    </message>
-    <message>
-        <source>Move To Top</source>
-        <translation type="vanished">Передвинуть вверх</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation type="vanished">Удалить</translation>
-    </message>
-    <message>
-        <source>Clear All</source>
-        <translation type="vanished">Очистить всё</translation>
-    </message>
-    <message>
-        <source>_Copy</source>
-        <translation type="vanished">_Копировать</translation>
-    </message>
-    <message>
-        <source>_Store…</source>
-        <translation type="vanished">_Сохранить…</translation>
-    </message>
-    <message>
-        <source>Save Image…</source>
-        <translation type="vanished">Сохранить изображение…</translation>
-    </message>
-    <message>
-        <source>_Factorize</source>
-        <translation type="vanished">Разло_жить на множители</translation>
-    </message>
-    <message>
-        <source>_Expand</source>
-        <translation type="vanished">Р_аскрывать</translation>
-    </message>
-    <message>
-        <source>_Normal</source>
-        <translation type="vanished">Обыч_ное</translation>
-    </message>
-    <message>
-        <source>Sc_ientific</source>
-        <translation type="vanished">На_учное</translation>
-    </message>
-    <message>
-        <source>Purel_y Scientific</source>
-        <translation type="vanished">Просто_е научное</translation>
-    </message>
-    <message>
-        <source>Simp_le</source>
-        <translation type="vanished">Прост_ое</translation>
-    </message>
-    <message>
-        <source>_Binary</source>
-        <translation type="vanished">Д_воичное</translation>
-    </message>
-    <message>
-        <source>_Octal</source>
-        <translation type="vanished">В_осьмеричное</translation>
-    </message>
-    <message>
-        <source>_Decimal</source>
-        <translation type="vanished">_Десятичное</translation>
-    </message>
-    <message>
-        <source>_Hexadecimal</source>
-        <translation type="vanished">_Шестнадцатеричное</translation>
-    </message>
-    <message>
-        <source>Decimal Fraction</source>
-        <translation type="vanished">Десятичная дробь</translation>
-    </message>
-    <message>
-        <source>Exact Decimal Fraction</source>
-        <translation type="vanished">Точная десятичная дробь</translation>
-    </message>
-    <message>
-        <source>Simple Fraction</source>
-        <translation type="vanished">Простая дробь</translation>
-    </message>
-    <message>
-        <source>Mixed Fraction</source>
-        <translation type="vanished">Смешанная дробь</translation>
-    </message>
-    <message>
-        <source>_Abbreviate Names</source>
-        <translation type="vanished">Сокр_ащённые имена</translation>
-    </message>
-    <message>
-        <source>C_onvert…</source>
-        <translation type="vanished">П_еревести…</translation>
-    </message>
-    <message>
-        <source>Convert to Base _Units</source>
-        <translation type="vanished">Преобразовать в базовую _единицу измерения</translation>
-    </message>
-    <message>
-        <source>Convert _to Optimal Unit</source>
-        <translation type="vanished">Преобразова_ть в оптимальные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Use Optimal Prefix</source>
-        <translation type="vanished">Использовать оптимальный префикс</translation>
-    </message>
-    <message>
-        <source>Convert to</source>
-        <translation type="vanished">Преобразовать к</translation>
-    </message>
-    <message>
-        <source>Convert to UTC</source>
-        <translation type="vanished">Преобразовать к UTC</translation>
-    </message>
-    <message>
-        <source>Convert to Calendars</source>
-        <translation type="vanished">Преобразовать к календарям</translation>
-    </message>
-    <message>
-        <source>Use prefixes for all units</source>
-        <translation type="vanished">Использовать префиксы для всех единиц измерения</translation>
-    </message>
-    <message>
-        <source>Enable All SI Prefi_xes</source>
-        <translation type="vanished">Включить все префи_ксы СИ</translation>
-    </message>
-    <message>
-        <source>View/Edit Matrix</source>
-        <translation type="vanished">Просмотр/изменение матрицы</translation>
-    </message>
-    <message>
-        <source>View/Edit Vector</source>
-        <translation type="vanished">Просмотр/изменение вектора</translation>
-    </message>
-    <message>
-        <source>Copy Text</source>
-        <translation type="vanished">Копировать текст</translation>
-    </message>
-    <message>
-        <source>To Top</source>
-        <translation type="vanished">Вверх</translation>
-    </message>
-    <message>
-        <source>Swap</source>
-        <translation type="vanished">Обменять</translation>
-    </message>
-    <message>
-        <source>Up</source>
-        <translation type="vanished">Верх</translation>
-    </message>
-    <message>
-        <source>Down</source>
-        <translation type="vanished">Низ</translation>
-    </message>
-    <message>
-        <source>Negate</source>
-        <translation type="vanished">Изменить знак</translation>
-    </message>
-    <message>
-        <source>Invert</source>
-        <translation type="vanished">Инвертировать</translation>
-    </message>
-    <message>
-        <source>Square</source>
-        <translation type="vanished">Квадрат</translation>
-    </message>
-    <message>
-        <source>Square Root</source>
-        <translation type="vanished">Квадратный корень</translation>
-    </message>
-    <message>
-        <source>Clear Stack</source>
-        <translation type="vanished">Очистить стек</translation>
-    </message>
-    <message>
-        <source>Select Number Base…</source>
-        <translation type="vanished">Выбрать основание системы счисления…</translation>
-    </message>
-    <message>
-        <source>Store result</source>
-        <translation type="vanished">Сохранить результат</translation>
-    </message>
-    <message>
-        <source>Add result</source>
-        <extracomment>Add current result to variable value</extracomment>
-        <translation type="vanished">Добавить результат</translation>
-    </message>
-    <message>
-        <source>Subtract result</source>
-        <extracomment>Subtruct current result from variable value</extracomment>
-        <translation type="vanished">Вычесть результат</translation>
-    </message>
-    <message>
-        <source>Insert the matrix/vector into the expression</source>
-        <translation type="vanished">Вставить матрицу/вектор в выражение</translation>
-    </message>
-    <message>
-        <source>Rows</source>
-        <translation type="vanished">Строки</translation>
-    </message>
-    <message>
-        <source>Number of rows in this matrix (rows displayed for vectors)</source>
-        <translation type="vanished">Количество строк в этой матрице (строки отображаются для векторов)</translation>
-    </message>
-    <message>
-        <source>Columns</source>
-        <translation type="vanished">Столбцы</translation>
-    </message>
-    <message>
-        <source>Number of columns in this matrix (columns displayed for vectors)</source>
-        <translation type="vanished">Количество столбцов в этой матрице (столбцы отображаются для векторов)</translation>
-    </message>
-    <message>
-        <source>If this is a matrix or vector</source>
-        <translation type="vanished">Если это матрица или вектор</translation>
-    </message>
-    <message>
-        <source>Elements</source>
-        <translation type="vanished">Компоненты</translation>
-    </message>
-    <message>
-        <source>Current element:</source>
-        <translation type="vanished">Текущий элемент:</translation>
-    </message>
-    <message>
-        <source>Edit Matrix</source>
-        <translation type="vanished">Изменить матрицу</translation>
-    </message>
-    <message>
-        <source>Do not create/modify this matrix/vector</source>
-        <translation type="vanished">Не создавать/не изменять эту матрицу/вектор</translation>
-    </message>
-    <message>
-        <source>Create/modify the matrix/vector</source>
-        <translation type="vanished">Создать/изменить матрицу/вектор</translation>
-    </message>
-    <message>
-        <source>Accept the creation/modification of this matrix/vector</source>
-        <translation type="vanished">Принять создание/изменение этой матрицы/вектора</translation>
-    </message>
-    <message>
-        <source>Name used to reference this variable in expressions</source>
-        <translation type="vanished">Имя, используемое для ссылки на эту переменную в выражениях</translation>
-    </message>
-    <message>
-        <source>Names</source>
-        <translation type="vanished">Имена</translation>
-    </message>
-    <message>
-        <source>Add new name</source>
-        <translation type="vanished">Добавить новое имя</translation>
-    </message>
-    <message>
-        <source>Apply changes to the selected name</source>
-        <translation type="vanished">Применить изменения к выбранному имени</translation>
-    </message>
-    <message>
-        <source>Remove the selected name</source>
-        <translation type="vanished">Удалить выбранное имя</translation>
-    </message>
-    <message>
-        <source>Abbreviation</source>
-        <translation type="vanished">Сокращение</translation>
-    </message>
-    <message>
-        <source>Unicode</source>
-        <translation type="vanished">Юникод</translation>
-    </message>
-    <message>
-        <source>Plural</source>
-        <translation type="vanished">Множественная форма</translation>
-    </message>
-    <message>
-        <source>Suffix</source>
-        <translation type="vanished">Суффикс</translation>
-    </message>
-    <message>
-        <source>Reference</source>
-        <translation type="vanished">Ссылка</translation>
-    </message>
-    <message>
-        <source>Avoid input</source>
-        <translation type="vanished">Избегать ввода</translation>
-    </message>
-    <message>
-        <source>Case sensitive</source>
-        <translation type="vanished">С учётом регистра</translation>
-    </message>
-    <message>
-        <source>Completion only</source>
-        <translation type="vanished">Только завершение</translation>
-    </message>
-    <message>
-        <source>Number Bases</source>
-        <translation type="vanished">Основания систем счисления</translation>
-    </message>
-    <message>
-        <source>Roman numerals</source>
-        <translation type="vanished">Римские цифры</translation>
-    </message>
-    <message>
-        <source>BIN</source>
-        <translation type="vanished">ДВ</translation>
-    </message>
-    <message>
-        <source>OCT</source>
-        <translation type="vanished">ВОСМ</translation>
-    </message>
-    <message>
-        <source>DEC</source>
-        <translation type="vanished">ДЕС</translation>
-    </message>
-    <message>
-        <source>DUO</source>
-        <translation type="vanished">ДВЕН</translation>
-    </message>
-    <message>
-        <source>HEX</source>
-        <translation type="vanished">ШЕСТ</translation>
-    </message>
-    <message>
-        <source>ROM</source>
-        <translation type="vanished">РИМ</translation>
-    </message>
-    <message>
-        <source>Subtract</source>
-        <translation type="vanished">Вычитание</translation>
-    </message>
-    <message>
-        <source>Multiply</source>
-        <translation type="vanished">Умножение</translation>
-    </message>
-    <message>
-        <source>Divide</source>
-        <translation type="vanished">Деление</translation>
-    </message>
-    <message>
-        <source>Bitwise AND</source>
-        <translation type="vanished">Побитовое И</translation>
-    </message>
-    <message>
-        <source>Bitwise OR</source>
-        <translation type="vanished">Побитовое ИЛИ</translation>
-    </message>
-    <message>
-        <source>Bitwise NOT</source>
-        <translation type="vanished">Побитовое НЕ</translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="vanished">Очистить</translation>
-    </message>
-    <message>
-        <source>Enter two values, of which at most one is a percentage, and the others will be calculated for you.</source>
-        <translation type="vanished">Введите два значения, максимум одно из которых является процентом, а остальные будут рассчитаны за вас.</translation>
-    </message>
-    <message>
-        <source>Percentage</source>
-        <translation type="vanished">Проценты</translation>
-    </message>
-    <message>
-        <source>Calculate</source>
-        <translation type="vanished">Рассчитать</translation>
-    </message>
-    <message>
-        <source>Value 1</source>
-        <translation type="vanished">Значение 1</translation>
-    </message>
-    <message>
-        <source>2 compared to 1</source>
-        <translation type="vanished">2 по сравнению к 1</translation>
-    </message>
-    <message>
-        <source>Change from 1 to 2</source>
-        <translation type="vanished">Изменение от 1 к 2</translation>
-    </message>
-    <message>
-        <source>Value 2</source>
-        <translation type="vanished">Значение 2</translation>
-    </message>
-    <message>
-        <source>1 compared to 2</source>
-        <translation type="vanished">1 по сравнению к 2</translation>
-    </message>
-    <message>
-        <source>Change from 2 to 1</source>
-        <translation type="vanished">Изменение от 2 к 1</translation>
-    </message>
-    <message>
-        <source>Plot</source>
-        <translation type="vanished">График</translation>
-    </message>
-    <message>
-        <source>_Save</source>
-        <translation type="vanished">_Сохранить</translation>
-    </message>
-    <message>
-        <source>Save as png, svg, postscript, eps, latex or fig</source>
-        <translation type="vanished">Сохранить как png, svg, postscript, eps, latex или fig.</translation>
-    </message>
-    <message>
-        <source>Vector/matrix</source>
-        <translation type="vanished">Вектор/матрица</translation>
-    </message>
-    <message>
-        <source>Paired matrix</source>
-        <translation type="vanished">Парная матрица</translation>
-    </message>
-    <message>
-        <source>if you want to split matrix in rows instead of columns</source>
-        <translation type="vanished">Если вы хотите разбить матрицу на строки вместо столбцов</translation>
-    </message>
-    <message>
-        <source>X variable</source>
-        <translation type="vanished">Переменная X</translation>
-    </message>
-    <message>
-        <source>The variable name used in expression</source>
-        <translation type="vanished">Имя переменной, используемое в выражении</translation>
-    </message>
-    <message>
-        <source>Style</source>
-        <translation type="vanished">Стиль</translation>
-    </message>
-    <message>
-        <source>Line</source>
-        <translation type="vanished">Линия</translation>
-    </message>
-    <message>
-        <source>Points</source>
-        <translation type="vanished">Символы</translation>
-    </message>
-    <message>
-        <source>Line with points</source>
-        <translation type="vanished">Линия с символами</translation>
-    </message>
-    <message>
-        <source>Boxes/bars</source>
-        <translation type="vanished">Прямоугольники/планки погрешностей</translation>
-    </message>
-    <message>
-        <source>Histogram</source>
-        <translation type="vanished">Гистограмма</translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="vanished">Ступенчатый</translation>
-    </message>
-    <message>
-        <source>Candlesticks</source>
-        <translation type="vanished">Японские свечи</translation>
-    </message>
-    <message>
-        <source>Dots</source>
-        <translation type="vanished">Точки</translation>
-    </message>
-    <message>
-        <source>Smoothing</source>
-        <translation type="vanished">Сглаживание</translation>
-    </message>
-    <message>
-        <source>Monotonic</source>
-        <translation type="vanished">Монотонное</translation>
-    </message>
-    <message>
-        <source>Natural cubic splines</source>
-        <translation type="vanished">Естественные кубические сплайны</translation>
-    </message>
-    <message>
-        <source>Bezier</source>
-        <translation type="vanished">Безье</translation>
-    </message>
-    <message>
-        <source>Bezier (monotonic)</source>
-        <translation type="vanished">Безье (монотонный)</translation>
-    </message>
-    <message>
-        <source>Y-axis</source>
-        <translation type="vanished">Ось Y</translation>
-    </message>
-    <message>
-        <source>Primary</source>
-        <translation type="vanished">Основная</translation>
-    </message>
-    <message>
-        <source>Secondary</source>
-        <translation type="vanished">Вторичная</translation>
-    </message>
-    <message>
-        <source>_Remove</source>
-        <translation type="vanished">_Удалить</translation>
-    </message>
-    <message>
-        <source>Data</source>
-        <translation type="vanished">Данные</translation>
-    </message>
-    <message>
-        <source>Minimum x value</source>
-        <translation type="vanished">Минимальное значение x</translation>
-    </message>
-    <message>
-        <source>Maximum x value</source>
-        <translation type="vanished">Максимальное значение x</translation>
-    </message>
-    <message>
-        <source>Sampling rate</source>
-        <translation type="vanished">Частота дискретизации</translation>
-    </message>
-    <message>
-        <source>Step size</source>
-        <translation type="vanished">Размер шага</translation>
-    </message>
-    <message>
-        <source>Function Range</source>
-        <translation type="vanished">Диапазон функция</translation>
-    </message>
-    <message>
-        <source>Display grid</source>
-        <translation type="vanished">Показать сетку</translation>
-    </message>
-    <message>
-        <source>Display full border</source>
-        <translation type="vanished">Показать полную рамку</translation>
-    </message>
-    <message>
-        <source>Minimum y value</source>
-        <translation type="vanished">Минимальное значение y</translation>
-    </message>
-    <message>
-        <source>Maximum y value</source>
-        <translation type="vanished">Максимальное значение y</translation>
-    </message>
-    <message>
-        <source>Logarithmic x scale</source>
-        <translation type="vanished">Логарифмическая шкала абсцисс x</translation>
-    </message>
-    <message>
-        <source>Logarithmic y scale</source>
-        <translation type="vanished">Логарифмическая шкала ординат y</translation>
-    </message>
-    <message>
-        <source>X-axis label</source>
-        <translation type="vanished">Подпись для оси абсцисс X</translation>
-    </message>
-    <message>
-        <source>Y-axis label</source>
-        <translation type="vanished">Подпись для оси ординат Y</translation>
-    </message>
-    <message>
-        <source>Line width</source>
-        <translation type="vanished">Толщина линии</translation>
-    </message>
-    <message>
-        <source>Color display</source>
-        <translation type="vanished">Цветной вывод</translation>
-    </message>
-    <message>
-        <source>Color</source>
-        <translation type="vanished">Цветной</translation>
-    </message>
-    <message>
-        <source>Monochrome</source>
-        <translation type="vanished">Монохромный</translation>
-    </message>
-    <message>
-        <source>Legend placement</source>
-        <translation type="vanished">Размещение легенды</translation>
-    </message>
-    <message>
-        <source>Top-left</source>
-        <translation type="vanished">Сверху слева</translation>
-    </message>
-    <message>
-        <source>Top-right</source>
-        <translation type="vanished">Сверху справа</translation>
-    </message>
-    <message>
-        <source>Bottom-left</source>
-        <translation type="vanished">Снизу слева</translation>
-    </message>
-    <message>
-        <source>Bottom-right</source>
-        <translation type="vanished">Снизу справа</translation>
-    </message>
-    <message>
-        <source>Below</source>
-        <translation type="vanished">Ниже</translation>
-    </message>
-    <message>
-        <source>Outside</source>
-        <translation type="vanished">Извне</translation>
-    </message>
-    <message>
-        <source>Appearance</source>
-        <translation type="vanished">Внешний вид</translation>
-    </message>
-    <message>
-        <source>Precision</source>
-        <translation type="vanished">Точность</translation>
-    </message>
-    <message>
-        <source>_Recalculate</source>
-        <translation type="vanished">Пе_ресчитать</translation>
-    </message>
-    <message>
-        <source>Recalculate expression</source>
-        <translation type="vanished">Пересчитать выражение</translation>
-    </message>
-    <message>
-        <source>The number of significant digits to display/calculate (simple arithmetics are always calculated exact)</source>
-        <translation type="vanished">Количество значащих цифр для отображения/вычисления (простая арифметика всегда рассчитывается точно)</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Параметры</translation>
-    </message>
-    <message>
-        <source>Save mode on exit</source>
-        <translation type="vanished">Сохранять режим при выходе</translation>
-    </message>
-    <message>
-        <source>If the mode of the calculator shall be restored</source>
-        <translation type="vanished">Если нужно восстанавливать режим калькулятора</translation>
-    </message>
-    <message>
-        <source>Save definitions on exit</source>
-        <translation type="vanished">Сохранять определения при выходе</translation>
-    </message>
-    <message>
-        <source>If changes to functions, units and variables shall be saved automatically</source>
-        <translation type="vanished">Если изменения в функциях, единицах измерения и переменных должны сохраняться автоматически.</translation>
-    </message>
-    <message>
-        <source>Clear history on exit</source>
-        <translation type="vanished">Очищать историю при выходе</translation>
-    </message>
-    <message>
-        <source>Allow multiple instances</source>
-        <translation type="vanished">Разрешить несколько экземпляров</translation>
-    </message>
-    <message>
-        <source>Allow multiple instances of the Qalculate! main window to be open at the same time. 
-
-Note that only the mode, history and definitions of the last closed instance will be saved.</source>
-        <translation type="vanished">Разрешить одновременное открытие нескольких экземпляров главного окна Qalculate!.
-
-Обратите внимание, что будут сохранены режим, история и определения только последнего закрытого экземпляра.</translation>
-    </message>
-    <message>
-        <source>Notify when a new version is available</source>
-        <translation type="vanished">Уведомлять, когда доступна новая версия</translation>
-    </message>
-    <message>
-        <source>Use keyboard keys for RPN</source>
-        <translation type="vanished">Использовать клавиатуру для ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>Use keyboard operator keys for RPN operations (+-*/^).</source>
-        <translation type="vanished">Использовать операторные клавиши клавиатуры для операций ПОЛИЗ (+-*/^).</translation>
-    </message>
-    <message>
-        <source>Use caret for bitwise XOR</source>
-        <translation type="vanished">Использовать карет для побитового исключающего ИЛИ</translation>
-    </message>
-    <message>
-        <source>Input XOR (⊻) using caret (^) on keyboard (otherwise use Ctrl+^). The exponentiation operator (^) can always be input using Ctrl+*.</source>
-        <translation type="vanished">Вводить исключающее ИЛИ (⊻), используя карет (^) на клавиатуре (в противном случае используйте Ctrl+^). Оператор возведения в степень (^) всегда можно ввести с помощью Ctrl+*.</translation>
-    </message>
-    <message>
-        <source>Add calculate-as-you-type result to history</source>
-        <translation type="vanished">Добавить в историю результат вычисления по мере ввода</translation>
-    </message>
-    <message>
-        <source>Delay:</source>
-        <translation type="vanished">Задержка:</translation>
-    </message>
-    <message>
-        <source>Time limit for plot:</source>
-        <translation type="vanished">Ограничение по времени для построения графиков</translation>
-    </message>
-    <message>
-        <source>Behavior</source>
-        <translation type="vanished">Поведение</translation>
-    </message>
-    <message>
-        <source>Enable Unicode symbols</source>
-        <translation type="vanished">Включить символы Юникода</translation>
-    </message>
-    <message>
-        <source>Disable this if you have problems with some fancy characters</source>
-        <translation type="vanished">Отключить, если у вас проблемы с некоторыми изящными символами</translation>
-    </message>
-    <message>
-        <source>Ignore system language (requires restart)</source>
-        <translation type="vanished">Игнорировать системный язык (требуется перезапуск)</translation>
-    </message>
-    <message>
-        <source>Use system tray icon</source>
-        <translation type="vanished">Использовать значок для системного лотка</translation>
-    </message>
-    <message>
-        <source>Hides the application in the system tray when the main window is closed</source>
-        <translation type="vanished">Скрывать приложение в системном лотке, когда главное окно закрыто</translation>
-    </message>
-    <message>
-        <source>Hide on startup</source>
-        <translation type="vanished">Скрывать при запуске</translation>
-    </message>
-    <message>
-        <source>Remember window position</source>
-        <translation type="vanished">Запоминать расположение окна</translation>
-    </message>
-    <message>
-        <source>Keep above other windows</source>
-        <translation type="vanished">Поддерживать поверх других окон</translation>
-    </message>
-    <message>
-        <source>Keep the main window above other windows (depending on platform and settings this might not work)</source>
-        <translation type="vanished">Поддерживать главное окно поверх других окон (в зависимости от платформы и настроек это может не работать)</translation>
-    </message>
-    <message>
-        <source>Application name</source>
-        <translation type="vanished">Имя приложения</translation>
-    </message>
-    <message>
-        <source>Result</source>
-        <translation type="vanished">Результат</translation>
-    </message>
-    <message>
-        <source>Application name + result</source>
-        <translation type="vanished">Имя приложения + результат</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="vanished">Режим</translation>
-    </message>
-    <message>
-        <source>Application name + mode</source>
-        <translation type="vanished">Имя приложения + режим</translation>
-    </message>
-    <message>
-        <source>Window title</source>
-        <translation type="vanished">Заголовок окна</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">По умолчанию</translation>
-    </message>
-    <message>
-        <source>Light</source>
-        <translation type="vanished">Светлый</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="vanished">Тёмный</translation>
-    </message>
-    <message>
-        <source>High contrast</source>
-        <translation type="vanished">Высококонтрастный</translation>
-    </message>
-    <message>
-        <source>Dark high contrast</source>
-        <translation type="vanished">Тёмный высококонтрастный</translation>
-    </message>
-    <message>
-        <source>Theme</source>
-        <translation type="vanished">Тема</translation>
-    </message>
-    <message>
-        <source>Button padding</source>
-        <translation type="vanished">Цвет фона кнопок</translation>
-    </message>
-    <message>
-        <source>/</source>
-        <translation type="vanished">/</translation>
-    </message>
-    <message>
-        <source>Number of expression lines</source>
-        <translation type="vanished">Количество строк для выражения</translation>
-    </message>
-    <message>
-        <source>3</source>
-        <translation type="vanished">3</translation>
-    </message>
-    <message>
-        <source>Display expression status</source>
-        <translation type="vanished">Показывать статус выражения</translation>
-    </message>
-    <message>
-        <source>If as-you-type expression status shall be displayed below the expression entry</source>
-        <translation type="vanished">Если статус выражения должен отображаться под записью выражения по мере набора</translation>
-    </message>
-    <message>
-        <source>Persistent keypad</source>
-        <translation type="vanished">Постоянная клавиатура</translation>
-    </message>
-    <message>
-        <source>Look &amp; Feel</source>
-        <translation type="vanished">Внешний вид</translation>
-    </message>
-    <message>
-        <source>Binary two&apos;s complement representation</source>
-        <translation type="vanished">Представление двоичных чисел с дополнительным кодом</translation>
-    </message>
-    <message>
-        <source>If two&apos;s complement representation shall be used for negative binary numbers.</source>
-        <translation type="vanished">Если двоичное дополнение должно использоваться для отрицательных двоичных чисел.</translation>
-    </message>
-    <message>
-        <source>Hexadecimal two&apos;s complement representation</source>
-        <translation type="vanished">Представление шестнадцатеричных чисел с дополнительным кодом</translation>
-    </message>
-    <message>
-        <source>If two&apos;s complement representation shall be used for negative hexadecimal numbers.</source>
-        <translation type="vanished">Если двоичное дополнение должно использоваться для отрицательных шестнадцатеричных чисел.</translation>
-    </message>
-    <message>
-        <source>Use lower case letters in non-decimal numbers</source>
-        <translation type="vanished">Использовать строчные буквы в недесятичных числах</translation>
-    </message>
-    <message>
-        <source>If lower case letters should be used in numbers with non-decimal base</source>
-        <translation type="vanished">Если в числах с недесятичным основанием следует использовать строчные буквы</translation>
-    </message>
-    <message>
-        <source>Alternative base prefixes</source>
-        <translation type="vanished">Альтернативные префиксы основания</translation>
-    </message>
-    <message>
-        <source>If hexadecimal numbers shall be displayed with &quot;0x0&quot; and binary numbers with &quot;0b00&quot; as prefixes</source>
-        <translation type="vanished">Если шестнадцатеричные числа должны отображаться с «0x0», а двоичные числа с «0b00» в качестве префиксов</translation>
-    </message>
-    <message>
-        <source>Spell out logical operators</source>
-        <translation type="vanished">Изложить логично логические операции</translation>
-    </message>
-    <message>
-        <source>If logical and/or shall be displayed as &quot;&amp;&amp;&quot;/&quot;||&quot; or &quot;and&quot;/&quot;or&quot;</source>
-        <translation type="vanished">Если логические И/ИЛИ должны отображаться как «&amp;&amp;»/«||» или «и»/«или»</translation>
-    </message>
-    <message>
-        <source>If &quot;e&quot; shall be used instead of &quot;E&quot; in numbers</source>
-        <translation type="vanished">Если в числах следует использовать букву «e» вместо «E»</translation>
-    </message>
-    <message>
-        <source>Use E-notation instead of 10&lt;sup&gt;&lt;i&gt;n&lt;/i&gt;&lt;/sup&gt;</source>
-        <translation type="vanished">Использовать E-нотацию вместо 10&lt;sup&gt;&lt;i&gt;n&lt;/i&gt;&lt;/sup&gt;</translation>
-    </message>
-    <message>
-        <source>Use lower case &quot;e&quot; (as in 1e10)</source>
-        <translation type="vanished">Использовать строчную букву «e» (как в 1e10)</translation>
-    </message>
-    <message>
-        <source>Use &apos;j&apos; as imaginary unit</source>
-        <translation type="vanished">Использовать «j» для мнимой единицы</translation>
-    </message>
-    <message>
-        <source>Use &apos;j&apos; (instead of &apos;i&apos;) as default symbol for the imaginary unit, and place it in front the imaginary part.</source>
-        <translation type="vanished">Использовать «j» (вместо «i») в качестве символа по умолчанию для мнимой единицы и помещать его перед мнимой частью.</translation>
-    </message>
-    <message>
-        <source>Use comma as decimal separator</source>
-        <translation type="vanished">Использовать точку в качестве десятичного разделителя</translation>
-    </message>
-    <message>
-        <source>Allow dots, &apos;.&apos;,  to be used as thousands separator instead of as an alternative decimal sign</source>
-        <translation type="vanished">Разрешить использование точек «.» в качестве разделителя тысяч вместо альтернативного десятичного знака</translation>
-    </message>
-    <message>
-        <source>Ignore comma in numbers</source>
-        <translation type="vanished">Игнорировать запятую в числах</translation>
-    </message>
-    <message>
-        <source>Allow commas, &apos;,&apos;,  to be used as thousands separator instead of as an function argument separator</source>
-        <translation type="vanished">Разрешить использование запятых «,» в качестве разделителя тысяч вместо разделителя аргументов функции</translation>
-    </message>
-    <message>
-        <source>Ignore dots in numbers</source>
-        <translation type="vanished">Игнорировать точки в числах</translation>
-    </message>
-    <message>
-        <source>Digit grouping</source>
-        <translation type="vanished">Группировка цифр</translation>
-    </message>
-    <message>
-        <source>off</source>
-        <translation type="vanished">выкл.</translation>
-    </message>
-    <message>
-        <source>standard</source>
-        <translation type="vanished">стандарт</translation>
-    </message>
-    <message>
-        <source>local</source>
-        <translation type="vanished">локаль</translation>
-    </message>
-    <message>
-        <source>Multiplication sign</source>
-        <translation type="vanished">Знак умножения</translation>
-    </message>
-    <message>
-        <source>Division sign</source>
-        <translation type="vanished">Знак деления</translation>
-    </message>
-    <message>
-        <source>Copy digit separator</source>
-        <translation type="vanished">Копировать разделитель цифр</translation>
-    </message>
-    <message>
-        <source>Deactivate to remove digit separator when copying result</source>
-        <translation type="vanished">Деактивировать, чтобы удалять разделитель цифр при копировании результата</translation>
-    </message>
-    <message>
-        <source>Numbers &amp; Operators</source>
-        <translation type="vanished">Числа и операторы</translation>
-    </message>
-    <message>
-        <source>Use binary prefixes for information units</source>
-        <translation type="vanished">Использовать двоичные префиксы для информационных единиц</translation>
-    </message>
-    <message>
-        <source>Use binary, instead of decimal, prefixes by default for information units (e.g. bytes).</source>
-        <translation type="vanished">По умолчанию использовать двоичные префиксы вместо десятичных для информационных единиц (например, байтов).</translation>
-    </message>
-    <message>
-        <source>Conversion to local currency</source>
-        <translation type="vanished">Преобразование в местную валюту</translation>
-    </message>
-    <message>
-        <source>Automatically convert to the local currency when optimal unit conversion is activated.</source>
-        <translation type="vanished">Автоматическое преобразование в местную валюту при включении оптимального преобразования единиц измерения.</translation>
-    </message>
-    <message>
-        <source>Update exchange rates on start</source>
-        <translation type="vanished">Обновлять курсы валют при запуске</translation>
-    </message>
-    <message>
-        <source>If current exchange rates shall be downloaded from the internet at program start</source>
-        <translation type="vanished">Если текущие курсы валют должны быть загружены из Интернета при запуске программы</translation>
-    </message>
-    <message>
-        <source>Exchange rates updates</source>
-        <translation type="vanished">Обновления курсов валют</translation>
-    </message>
-    <message>
-        <source>Temperature calculation mode:</source>
-        <translation type="vanished">Режим расчёта температуры</translation>
-    </message>
-    <message>
-        <source>Absolute</source>
-        <translation type="vanished">Абсолютный</translation>
-    </message>
-    <message>
-        <source>Relative</source>
-        <translation type="vanished">Относительный</translation>
-    </message>
-    <message>
-        <source>Hybrid</source>
-        <translation type="vanished">Гибридный</translation>
-    </message>
-    <message>
-        <source>Units &amp; Currencies</source>
-        <translation type="vanished">Единицы измерения и валюты</translation>
-    </message>
-    <message>
-        <source>Show expression completion suggestions</source>
-        <translation type="vanished">Показать варианты завершения выражения</translation>
-    </message>
-    <message>
-        <source>Search titles and countries</source>
-        <translation type="vanished">Искать в заголовках и странах</translation>
-    </message>
-    <message>
-        <source>Minimum characters</source>
-        <translation type="vanished">Минимальное количество символов</translation>
-    </message>
-    <message>
-        <source>Popup delay (ms)</source>
-        <translation type="vanished">Задержка всплывающего окна (мс)</translation>
-    </message>
-    <message>
-        <source>Completion</source>
-        <translation type="vanished">Завершение</translation>
-    </message>
-    <message>
-        <source>Status warning color</source>
-        <translation type="vanished">Цвет состояния предупреждения</translation>
-    </message>
-    <message>
-        <source>Status error color</source>
-        <translation type="vanished">Цвет состояния ошибки</translation>
-    </message>
-    <message>
-        <source>Custom status font</source>
-        <translation type="vanished">Шрифт состояния</translation>
-    </message>
-    <message>
-        <source>If you want to use a font other than the default in the status display below the expression entry</source>
-        <translation type="vanished">Если вы хотите использовать шрифт, отличный от шрифта по умолчанию, в отображении состояния под записью выражения</translation>
-    </message>
-    <message>
-        <source>Custom expression font</source>
-        <translation type="vanished">Шрифт выражения</translation>
-    </message>
-    <message>
-        <source>If you want to use a font other than the default in the expression entry</source>
-        <translation type="vanished">Если вы хотите использовать шрифт, отличный от шрифта по умолчанию, в записи выражения</translation>
-    </message>
-    <message>
-        <source>Custom result font</source>
-        <translation type="vanished">Шрифт результатов</translation>
-    </message>
-    <message>
-        <source>If you want to use a font other than the default in the result display</source>
-        <translation type="vanished">Если вы хотите использовать шрифт, отличный от шрифта по умолчанию, в отображении результатов</translation>
-    </message>
-    <message>
-        <source>Custom keypad font</source>
-        <translation type="vanished">Шрифт клавиатуры</translation>
-    </message>
-    <message>
-        <source>If you want to use a font other than the default in the keypad</source>
-        <translation type="vanished">Если вы хотите использовать шрифт, отличный от шрифта по умолчанию на клавиатуре</translation>
-    </message>
-    <message>
-        <source>Custom application font</source>
-        <translation type="vanished">Шрифт приложения</translation>
-    </message>
-    <message>
-        <source>If you want to use a font other than the default for the whole application</source>
-        <translation type="vanished">Если вы хотите использовать шрифт, отличный от шрифта по умолчанию для всего приложения</translation>
-    </message>
-    <message>
-        <source>Text color</source>
-        <translation type="vanished">Цвет текста</translation>
-    </message>
-    <message>
-        <source>Fonts &amp; Colors</source>
-        <translation type="vanished">Шрифты и цвета</translation>
-    </message>
-    <message>
-        <source>Other:</source>
-        <translation type="vanished">Другое:</translation>
-    </message>
-    <message>
-        <source>Bijective base-26</source>
-        <translation type="vanished">Биективное основание-26</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;Result Base&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Основание результата&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;Expression Base&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Основание выражения&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>New Keyboard Shortcut</source>
-        <translation type="vanished">Новая клавиатурная комбинация</translation>
-    </message>
-    <message>
-        <source>Edit Variable</source>
-        <translation type="vanished">Изменить переменную</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Дополнительно</translation>
-    </message>
-    <message>
-        <source>Accept the creation/modification of this variable</source>
-        <translation type="vanished">Принять создание/изменение этой переменной</translation>
-    </message>
-    <message>
-        <source>x, y, z</source>
-        <translation type="vanished">x, y, z</translation>
-    </message>
-    <message>
-        <source>Use x, y and z for 1st, 2nd and 3rd function argument, respectively.</source>
-        <translation type="vanished">Используйте x, y и z для 1-го, 2-го и 3-го аргумента функции соответственно.</translation>
-    </message>
-    <message>
-        <source>\x, \y, \z</source>
-        <translation type="vanished">\x, \y, \z</translation>
-    </message>
-    <message>
-        <source>Use \x, \y and \z for 1st, 2nd and 3rd function argument, respectively. This avoids potential conflicts with variables, functions and units.</source>
-        <translation type="vanished">Используйте \x, \y и \z для 1-го, 2-го и 3-го аргумента функции соответственно. Это позволяет избежать потенциальных конфликтов с переменными, функциями и единицами измерения.</translation>
-    </message>
-    <message>
-        <source>Edit Unit</source>
-        <translation type="vanished">Изменить единицу измерения</translation>
-    </message>
-    <message>
-        <source>Do not create/modify this unit</source>
-        <translation type="vanished">Не создавать/не изменять эту единицу измерения</translation>
-    </message>
-    <message>
-        <source>Accept the creation/modification of this unit</source>
-        <translation type="vanished">Принять создание/изменение этой единицы измерения</translation>
-    </message>
-    <message>
-        <source>Singular form of this unit&apos;s name</source>
-        <translation type="vanished">Форма единственного числа в названии этой единицы измерения</translation>
-    </message>
-    <message>
-        <source>Title displayed in menus and in unit manager</source>
-        <translation type="vanished">Заголовок, отображаемый в меню и в диспетчере единиц измерения</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation type="vanished">Система</translation>
-    </message>
-    <message>
-        <source>Imperial</source>
-        <translation type="vanished">Имперская/Британская</translation>
-    </message>
-    <message>
-        <source>US Survey</source>
-        <translation type="vanished">Американская геодезическая</translation>
-    </message>
-    <message>
-        <source>Hide unit</source>
-        <translation type="vanished">Скрыть единицу измерения</translation>
-    </message>
-    <message>
-        <source>If this unit shall be hidden in menus</source>
-        <translation type="vanished">Если эта единица измерения должна быть скрыта в меню</translation>
-    </message>
-    <message>
-        <source>Class</source>
-        <translation type="vanished">Класс</translation>
-    </message>
-    <message>
-        <source>The class that this unit belongs to. Named derived units are defined in relation to a single other unit, with an optional exponent, while (unnamed) derived units are defined by a unit expression with one or multiple units.</source>
-        <translation type="vanished">Класс, к которому принадлежит эта единица измерения. Именованные производные единицы измерения определяются по отношению к другой единице измерения с необязательным показателем, в то время как безымянные производные единицы измерения определяются выражением через одну или несколько единиц измерения.</translation>
-    </message>
-    <message>
-        <source>Base unit</source>
-        <translation type="vanished">Основная единица измерения</translation>
-    </message>
-    <message>
-        <source>Named derived unit</source>
-        <translation type="vanished">Именованная производная единица измерения</translation>
-    </message>
-    <message>
-        <source>Derived unit</source>
-        <translation type="vanished">Производная единица измерения</translation>
-    </message>
-    <message>
-        <source>Base unit(s)</source>
-        <translation type="vanished">Основная(ые) единица(ы) измерения</translation>
-    </message>
-    <message>
-        <source>Unit (for named derived unit) or unit expression (for unnamed derived unit) that this unit as defined in relation to</source>
-        <translation type="vanished">Единица измерения (для именованной производной единицы измерения) или выражение единицы измерения (для безымянной производной единицы измерения), в отношении которой определена редактируемая единица измерения</translation>
-    </message>
-    <message>
-        <source>Exponent</source>
-        <translation type="vanished">Показатель</translation>
-    </message>
-    <message>
-        <source>Exponent of the base unit</source>
-        <translation type="vanished">Показатель базовой единицы измерения</translation>
-    </message>
-    <message>
-        <source>Relation</source>
-        <translation type="vanished">Отношение</translation>
-    </message>
-    <message>
-        <source>Relation to the base unit. For linear relations this should just be a number.
-
-For non-linear relations use \x for the factor and \y for the exponent (e.g. &quot;\x + 273.15&quot; for the relation between degrees Celsius and Kelvin).</source>
-        <translation type="vanished">Отношение к основной единице измерения. Для линейных отношений это должно быть просто число.
-
-Для нелинейных отношений используйте \ x для множителя и \ y для показателя степени (например, «\x + 273,15» для отношения между градусами Цельсия и Кельвина).</translation>
-    </message>
-    <message>
-        <source>Relation is exact</source>
-        <translation type="vanished">Отношение точно</translation>
-    </message>
-    <message>
-        <source>If the relation is precise</source>
-        <translation type="vanished">Если отношение точное</translation>
-    </message>
-    <message>
-        <source>Inverse relation</source>
-        <translation type="vanished">Обратное отношение</translation>
-    </message>
-    <message>
-        <source>Specify for non-linear relation, for conversion back to the base unit.</source>
-        <translation type="vanished">Указать для нелинейного отношения, чтобы обратно преобразовать в базовую единицу измерения.</translation>
-    </message>
-    <message>
-        <source>Mix with base unit</source>
-        <translation type="vanished">Смешивать с базовой единицей измерения</translation>
-    </message>
-    <message>
-        <source>- Decides which units the base unit is mixed with if multple options exist.
-- The original unit will not be mixed with units with lower priority.
-- A lower value means higher priority.</source>
-        <translation type="vanished">- Решает, с какими единицами смешивается базовая единица измерения, если существует несколько вариантов.
-- Исходный объект не будет смешиваться с объектами с более низким приоритетом.
-- Меньшее значение означает более высокий приоритет.</translation>
-    </message>
-    <message>
-        <source>Priority</source>
-        <translation type="vanished">Приоритет</translation>
-    </message>
-    <message>
-        <source>Minimum base unit number</source>
-        <translation type="vanished">Минимальное количество базовой единицы измерения</translation>
-    </message>
-    <message>
-        <source>Use with prefixes by default</source>
-        <translation type="vanished">По умолчанию использовать с префиксами</translation>
-    </message>
-    <message>
-        <source>Create a new unit</source>
-        <translation type="vanished">Создать новую единицу измерения</translation>
-    </message>
-    <message>
-        <source>Edit the selected unit</source>
-        <translation type="vanished">Изменить выбранную единицу измерения</translation>
-    </message>
-    <message>
-        <source>Insert the selected unit into the expression entry</source>
-        <translation type="vanished">Вставить выбранную единицу измерения в выражение</translation>
-    </message>
-    <message>
-        <source>C_onvert</source>
-        <translation type="vanished">П_еревести</translation>
-    </message>
-    <message>
-        <source>Convert the result to the selected unit</source>
-        <translation type="vanished">Преобразуйте результат в выбранную единицу измерения</translation>
-    </message>
-    <message>
-        <source>Delete the selected unit</source>
-        <translation type="vanished">Удалить выбранную единицу измерения</translation>
-    </message>
-    <message>
-        <source>(De)activate the selected unit</source>
-        <translation type="vanished">(Де)активировать выбранную единицу измерения</translation>
-    </message>
-    <message>
-        <source>_Unit</source>
-        <translation type="vanished">_Единица измерения</translation>
-    </message>
-    <message>
-        <source>Convert between units</source>
-        <translation type="vanished">Преобразовать между единицами измерения</translation>
-    </message>
-    <message>
-        <source>=</source>
-        <translation type="vanished">=</translation>
-    </message>
-    <message>
-        <source>Conver_sion</source>
-        <translation type="vanished">_Преобразование</translation>
-    </message>
-    <message>
-        <source>Converted value</source>
-        <translation type="vanished">Преобразованное значение</translation>
-    </message>
-    <message>
-        <source>Value to convert from</source>
-        <translation type="vanished">Значение, которое нужно преобразовать</translation>
-    </message>
-    <message>
-        <source>Type anywhere</source>
-        <translation type="vanished">Печатать где угодно</translation>
-    </message>
-    <message>
-        <source>Edit Unknown Variable</source>
-        <translation type="vanished">Изменить переменную неизвестного</translation>
-    </message>
-    <message>
-        <source>Do not create/modify this unknown variable</source>
-        <translation type="vanished">Не создавать/не изменять эту переменную неизвестного</translation>
-    </message>
-    <message>
-        <source>Accept the creation/modification of this unknown variable</source>
-        <translation type="vanished">Принять создание/изменение этой переменной неизвестного</translation>
-    </message>
-    <message>
-        <source>Name used to reference this unknown variable in expressions</source>
-        <translation type="vanished">Имя, используемое для ссылки на эту переменную неизвестного в выражениях</translation>
-    </message>
-    <message>
-        <source>Use custom assumptions</source>
-        <translation type="vanished">Использовать собственные предположения</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation type="vanished">Тип</translation>
-    </message>
-    <message>
-        <source>Real Number</source>
-        <translation type="vanished">Действительное число</translation>
-    </message>
-    <message>
-        <source>Rational Number</source>
-        <translation type="vanished">Рациональное число</translation>
-    </message>
-    <message>
-        <source>Sign</source>
-        <translation type="vanished">Знак</translation>
-    </message>
-    <message>
-        <source>The category this unknown variable belongs to</source>
-        <translation type="vanished">Категория, к которой принадлежит эта переменная неизвестного</translation>
-    </message>
-    <message>
-        <source>Value of this variable (expression)</source>
-        <translation type="vanished">Значение этой переменной (выражение)</translation>
-    </message>
-    <message>
-        <source>value is exact</source>
-        <translation type="vanished">значение точное</translation>
-    </message>
-    <message>
-        <source>If the value is precise</source>
-        <translation type="vanished">Если значение точное</translation>
-    </message>
-    <message>
-        <source>The category this variable belongs to</source>
-        <translation type="vanished">Категория, к которой принадлежит эта переменная</translation>
-    </message>
-    <message>
-        <source>Create a new variable</source>
-        <translation type="vanished">Создать новую переменную</translation>
-    </message>
-    <message>
-        <source>Edit the selected variable</source>
-        <translation type="vanished">Изменить выбранную переменную</translation>
-    </message>
-    <message>
-        <source>Insert the selected variable into the expression entry</source>
-        <translation type="vanished">Вставить выбранную переменную в выражение</translation>
-    </message>
-    <message>
-        <source>Delete the selected variable</source>
-        <translation type="vanished">Удалить выбранную переменную</translation>
-    </message>
-    <message>
-        <source>(De)activate the selected variable</source>
-        <translation type="vanished">(Де)активировать выбранную переменную</translation>
-    </message>
-    <message>
-        <source>E_xport</source>
-        <translation type="vanished">_Экспортировать</translation>
-    </message>
-    <message>
-        <source>_Variable</source>
-        <translation type="vanished">_Переменная</translation>
-    </message>
-    <message>
-        <source>Execute expressions and commands from a file</source>
-        <translation type="vanished">Выполнить выражения и команды из файла</translation>
-    </message>
-    <message>
-        <source>Start a new instance of the application</source>
-        <translation type="vanished">Запустить новый экземпляр приложения</translation>
-    </message>
-    <message>
-        <source>Display the application version</source>
-        <translation type="vanished">Показать версию приложения</translation>
-    </message>
-    <message>
-        <source>Specify the window title</source>
-        <translation type="vanished">Укажите заголовок окна</translation>
-    </message>
-    <message>
-        <source>TITLE</source>
-        <translation type="vanished">НАЗВАНИЕ</translation>
-    </message>
-    <message>
-        <source>Expression to calculate</source>
-        <translation type="vanished">Выражение для вычисления</translation>
-    </message>
-    <message>
-        <source>[EXPRESSION]</source>
-        <translation type="vanished">[ВЫРАЖЕНИЕ]</translation>
-    </message>
-    <message>
-        <source>Type a mathematical expression above, e.g. &quot;5 + 2 / 3&quot;,
-and press the enter key.</source>
-        <translation type="vanished">Введите математическое выражение выше, например «5 + 2 / 3»,
-и нажмите клавишу ВВОД (Enter).</translation>
-    </message>
-    <message>
-        <source>ans</source>
-        <translation type="vanished">отв</translation>
-    </message>
-    <message>
-        <source>Last Answer</source>
-        <translation type="vanished">Последний ответ</translation>
-    </message>
-    <message>
-        <source>answer</source>
-        <translation type="vanished">ответ</translation>
-    </message>
-    <message>
-        <source>Answer 2</source>
-        <translation type="vanished">Ответ 2</translation>
-    </message>
-    <message>
-        <source>Answer 3</source>
-        <translation type="vanished">Ответ 3</translation>
-    </message>
-    <message>
-        <source>Answer 4</source>
-        <translation type="vanished">Ответ 4</translation>
-    </message>
-    <message>
-        <source>Answer 5</source>
-        <translation type="vanished">Ответ 5</translation>
-    </message>
-    <message>
-        <source>Memory</source>
-        <translation type="vanished">Память</translation>
-    </message>
-    <message>
-        <source>Failed to load global definitions!
-</source>
-        <translation type="vanished">Не удалось загрузить глобальные определения!
-</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>All</source>
-        <extracomment>if no category has been selected (previously selected has been renamed/deleted), select &quot;All&quot;</extracomment>
-        <translation type="vanished">Все</translation>
-    </message>
-    <message>
-        <source>By default, only one instance (one main window) of %s is allowed.
-
-If multiple instances are opened simultaneously, only the definitions (variables, functions, etc.), mode, preferences, and history of the last closed window will be saved.
-
-Do you, despite this, want to change the default bahvior and allow multiple simultaneous instances?</source>
-        <translation type="vanished">По умолчанию разрешён только один экземпляр (одно главное окно) %s.
-
-Если несколько экземпляров открыты одновременно, будут сохранены только определения (переменные, функции и т. д.), режим, настройки и история последнего закрытого окна.
-
-Вы, несмотря на это, хотите изменить поведение по умолчанию и разрешить одновременную работу нескольких экземпляров?</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Right-click/long press: %s</source>
-        <translation type="vanished">Щелчок правой кнопкой/долгое нажатие: %s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Right-click: %s</source>
-        <translation type="vanished">Щелчок правой кнопкой: %s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Middle-click: %s</source>
-        <translation type="vanished">Щелчок средней кнопкой: %s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Cycle through previous expression</source>
-        <translation type="vanished">Цикл через предыдущее выражение</translation>
-    </message>
-    <message>
-        <source>Move cursor left or right</source>
-        <translation type="vanished">Перемещать курсор влево или вправо</translation>
-    </message>
-    <message>
-        <source>Move cursor to beginning or end</source>
-        <translation type="vanished">Переместить курсор в начало или конец</translation>
-    </message>
-    <message>
-        <source>Uncertainty/interval</source>
-        <translation type="vanished">Неопределённость/интервал</translation>
-    </message>
-    <message>
-        <source>Relative error</source>
-        <translation type="vanished">Относительная ошибка</translation>
-    </message>
-    <message>
-        <source>Argument separator</source>
-        <translation type="vanished">Разделитель аргументов</translation>
-    </message>
-    <message>
-        <source>Blank space</source>
-        <translation type="vanished">Пустой пробел</translation>
-    </message>
-    <message>
-        <source>New line</source>
-        <translation type="vanished">Новая строка</translation>
-    </message>
-    <message>
-        <source>Smart parentheses</source>
-        <translation type="vanished">Умные скобки</translation>
-    </message>
-    <message>
-        <source>Vector brackets</source>
-        <translation type="vanished">Векторные скобки</translation>
-    </message>
-    <message>
-        <source>Left parenthesis</source>
-        <translation type="vanished">Левая скобка</translation>
-    </message>
-    <message>
-        <source>Left vector bracket</source>
-        <translation type="vanished">Левая векторная скобка</translation>
-    </message>
-    <message>
-        <source>Right parenthesis</source>
-        <translation type="vanished">Правая скобка</translation>
-    </message>
-    <message>
-        <source>Right vector bracket</source>
-        <translation type="vanished">Правая векторная скобка</translation>
-    </message>
-    <message>
-        <source>Decimal point</source>
-        <translation type="vanished">Десятичная точка</translation>
-    </message>
-    <message>
-        <source>Raise (Ctrl+*)</source>
-        <translation type="vanished">Возведение в степень (Ctrl+*)</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Сложение</translation>
-    </message>
-    <message>
-        <source>M+ (memory plus)</source>
-        <translation type="vanished">M+ (прибавить к значению в памяти)</translation>
-    </message>
-    <message>
-        <source>MC (memory clear)</source>
-        <translation type="vanished">MC (отчистить память)</translation>
-    </message>
-    <message>
-        <source>Backspace</source>
-        <translation type="vanished">Обратное перемещение</translation>
-    </message>
-    <message>
-        <source>M− (memory minus)</source>
-        <translation type="vanished">M− (отнять от значения в памяти)</translation>
-    </message>
-    <message>
-        <source>Previous result (static)</source>
-        <translation type="vanished">Предыдущий результат (статический)</translation>
-    </message>
-    <message>
-        <source>Calculate expression</source>
-        <translation type="vanished">Вычислить выражение</translation>
-    </message>
-    <message>
-        <source>MR (memory recall)</source>
-        <translation type="vanished">MR (вызвать из памяти)</translation>
-    </message>
-    <message>
-        <source>MS (memory store)</source>
-        <translation type="vanished">MS (сохранить в памяти)</translation>
-    </message>
-    <message>
-        <source>Set unknowns</source>
-        <translation type="vanished">Установить неизвестные</translation>
-    </message>
-    <message>
-        <source>more</source>
-        <extracomment>Show further items in a submenu</extracomment>
-        <translation type="vanished">ещё</translation>
-    </message>
-    <message>
-        <source>Logical AND</source>
-        <translation type="vanished">Логическое И</translation>
-    </message>
-    <message>
-        <source>Logical OR</source>
-        <translation type="vanished">Логическое ИЛИ</translation>
-    </message>
-    <message>
-        <source>Logical NOT</source>
-        <translation type="vanished">Логическое НЕ</translation>
-    </message>
-    <message>
-        <source>Toggle Result Base</source>
-        <translation type="vanished">В(ы)ключить основание результата</translation>
-    </message>
-    <message>
-        <source>Open menu with stored variables</source>
-        <translation type="vanished">Открыть меню с сохранёнными переменными</translation>
-    </message>
-    <message>
-        <source>Index</source>
-        <translation type="vanished">Индекс</translation>
-    </message>
-    <message>
-        <source>ENTER</source>
-        <extracomment>RPN Enter (calculate and add to stack)</extracomment>
-        <translation type="vanished">ВВОД</translation>
-    </message>
-    <message>
-        <source>Calculate expression and add to stack</source>
-        <translation type="vanished">Вычислить выражение и добавить в стек</translation>
-    </message>
-    <message>
-        <source>Flag</source>
-        <translation type="vanished">Флаг</translation>
-    </message>
-    <message>
-        <source>Matrices</source>
-        <translation type="vanished">Матрицы</translation>
-    </message>
-    <message>
-        <source>Gregorian</source>
-        <translation type="vanished">Григорианский</translation>
-    </message>
-    <message>
-        <source>Revised Julian (Milanković)</source>
-        <translation type="vanished">Пересмотренный юлианский (циклы Миланковича)</translation>
-    </message>
-    <message>
-        <source>Julian</source>
-        <translation type="vanished">Юлианский</translation>
-    </message>
-    <message>
-        <source>Islamic (Hijri)</source>
-        <translation type="vanished">Исламский (от Хиджры)</translation>
-    </message>
-    <message>
-        <source>Hebrew</source>
-        <translation type="vanished">Еврейский</translation>
-    </message>
-    <message>
-        <source>Chinese</source>
-        <translation type="vanished">Китайский</translation>
-    </message>
-    <message>
-        <source>Persian (Solar Hijri)</source>
-        <translation type="vanished">Иранский (Солнечная хиджра)</translation>
-    </message>
-    <message>
-        <source>Coptic</source>
-        <translation type="vanished">Коптский</translation>
-    </message>
-    <message>
-        <source>Ethiopian</source>
-        <translation type="vanished">Эфиопский</translation>
-    </message>
-    <message>
-        <source>Indian (National)</source>
-        <translation type="vanished">Индийский (национальный)</translation>
-    </message>
-    <message>
-        <source>Action</source>
-        <translation type="vanished">Действие</translation>
-    </message>
-    <message>
-        <source>Key combination</source>
-        <translation type="vanished">Комбинация клавиш</translation>
-    </message>
-    <message>
-        <source>Raise</source>
-        <translation type="vanished">Возведение в степень</translation>
-    </message>
-    <message>
-        <source>History Answer Value</source>
-        <translation type="vanished">Значение ответа в истории</translation>
-    </message>
-    <message>
-        <source>History Index(es)</source>
-        <translation type="vanished">Индекс(ы) истории</translation>
-    </message>
-    <message>
-        <source>History index %s does not exist.</source>
-        <translation type="vanished">Индекс истории %s не существует.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>expression</source>
-        <translation type="vanished">выражение</translation>
-    </message>
-    <message>
-        <source>History Parsed Expression</source>
-        <translation type="vanished">Анализированное выражения в истории</translation>
-    </message>
-    <message>
-        <source>Set Window Title</source>
-        <translation type="vanished">Установить заголовок окна</translation>
-    </message>
-    <message>
-        <source>Failed to open %s.
-%s</source>
-        <translation type="vanished">Не удалось открыть %s.
-%s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Could not display help for Qalculate!.</source>
-        <translation type="vanished">Не удалось отобразить справку по Qalculate!.</translation>
-    </message>
-    <message>
-        <source>Could not display help for Qalculate!.
-%s</source>
-        <translation type="vanished">Не удалось отобразить справку по Qalculate!.
-%s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>approx.</source>
-        <translation type="vanished">прибл.</translation>
-    </message>
-    <message>
-        <source>Stop process</source>
-        <translation type="vanished">Остановить процесс</translation>
-    </message>
-    <message>
-        <source>Clear expression</source>
-        <translation type="vanished">Отчистить выражение</translation>
-    </message>
-    <message>
-        <source>EXACT</source>
-        <translation type="vanished">ТОЧНО</translation>
-    </message>
-    <message>
-        <source>APPROX</source>
-        <translation type="vanished">ПРИБЛ</translation>
-    </message>
-    <message>
-        <source>RPN</source>
-        <translation type="vanished">ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>CHN</source>
-        <extracomment>Chain mode</extracomment>
-        <translation type="vanished">ЦЕПЬ</translation>
-    </message>
-    <message>
-        <source>ROMAN</source>
-        <translation type="vanished">РИМСКИЕ</translation>
-    </message>
-    <message>
-        <source>DEG</source>
-        <translation type="vanished">ГРД</translation>
-    </message>
-    <message>
-        <source>RAD</source>
-        <translation type="vanished">РАД</translation>
-    </message>
-    <message>
-        <source>GRA</source>
-        <translation type="vanished">ГРА</translation>
-    </message>
-    <message>
-        <source>PREC</source>
-        <translation type="vanished">ТОЧН</translation>
-    </message>
-    <message>
-        <source>FUNC</source>
-        <translation type="vanished">ФУНК</translation>
-    </message>
-    <message>
-        <source>UNIT</source>
-        <translation type="vanished">ЕД. ИЗМ</translation>
-    </message>
-    <message>
-        <source>VAR</source>
-        <translation type="vanished">ПЕР</translation>
-    </message>
-    <message>
-        <source>INF</source>
-        <translation type="vanished">БЕСК</translation>
-    </message>
-    <message>
-        <source>CPLX</source>
-        <translation type="vanished">КМКС</translation>
-    </message>
-    <message>
-        <source>Do you wish to update the exchange rates now?</source>
-        <translation type="vanished">Вы хотите обновить курсы обмена сейчас?</translation>
-    </message>
-    <message numerus="yes">
-        <source>It has been %s day since the exchange rates last were updated.</source>
-        <translation type="vanished">
-            <numerusform>Прошёл %s день с момента последнего обновления курсов обмена.</numerusform>
-            <numerusform>Прошло %s дня с момента последнего обновления курсов обмена.</numerusform>
-            <numerusform>Прошло %s дней с момента последнего обновления курсов обмена.</numerusform>
-        </translation>
-        <extra-po-flags>c-format</extra-po-flags>
-        <extra-po-msgid_plural>It has been %s days since the exchange rates last were updated.</extra-po-msgid_plural>
-    </message>
-    <message>
-        <source>Do not ask again</source>
-        <translation type="vanished">Не спрашивать снова</translation>
-    </message>
-    <message>
-        <source>It took too long to generate the plot data.</source>
-        <translation type="vanished">Создание графика для данных заняло слишком много времени.</translation>
-    </message>
-    <message>
-        <source>It took too long to generate the plot data. Please decrease the sampling rate or increase the time limit in preferences.</source>
-        <translation type="vanished">Создание графика для данных заняло слишком много времени. Уменьшите частоту дискретизации или увеличьте ограничение по времени в настройках.</translation>
-    </message>
-    <message>
-        <source>When errors, warnings and other information are generated during calculation, the icon in the upper right corner of the expression entry changes to reflect this. If you hold the pointer over or click the icon, the message will be shown.</source>
-        <translation type="vanished">Если во время расчёта генерируются ошибки, предупреждения и другая информация, значок в правом верхнем углу записи выражения изменяется, чтобы отразить это. Если удерживать указатель мыши или щелкнуть на значок, будет показано сообщение.</translation>
-    </message>
-    <message>
-        <source>Path of executable not found.</source>
-        <translation type="vanished">Путь к исполняемому файлу не найден.</translation>
-    </message>
-    <message>
-        <source>curl not found.</source>
-        <translation type="vanished">Программа curl не найдена.</translation>
-    </message>
-    <message>
-        <source>Failed to run update script.
-%s</source>
-        <translation type="vanished">Не удалось запустить скрипт обновления.
-%s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Failed to check for updates.</source>
-        <translation type="vanished">Не удалось проверить наличие обновлений.</translation>
-    </message>
-    <message>
-        <source>No updates found.</source>
-        <translation type="vanished">Обновлений не найдено.</translation>
-    </message>
-    <message>
-        <source>A new version of %s is available at %s.
-
-Do you wish to update to version %s.</source>
-        <translation type="vanished">Новая версия %s доступна на %s.
-
-Вы хотите обновиться до версии %s?</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>A new version of %s is available.
-
-You can get version %s at %s.</source>
-        <translation type="vanished">Доступна новая версия %s.
-
-Вы можете получить версию %s на %s.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Too many arguments for %s().</source>
-        <translation type="vanished">Слишком много аргументов для %s().</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>argument</source>
-        <translation type="vanished">аргумент</translation>
-    </message>
-    <message>
-        <source>Temperature Calculation Mode</source>
-        <translation type="vanished">Режим расчёта температуры</translation>
-    </message>
-    <message>
-        <source>The expression is ambiguous.
-Please select temperature calculation mode
-(the mode can later be changed in preferences).</source>
-        <translation type="vanished">Выражение неоднозначное.
-Выберите режим расчёта температуры
-(режим позже можно изменить в настройках).</translation>
-    </message>
-    <message>
-        <source>Interpretation of dots</source>
-        <translation type="vanished">Использование точки</translation>
-    </message>
-    <message>
-        <source>Please select interpretation of dots (&quot;.&quot;)
-(this can later be changed in preferences).</source>
-        <translation type="vanished">Выберите использование точки («.»)
-(позже это можно изменить в настройках).</translation>
-    </message>
-    <message>
-        <source>Both dot and comma as decimal separators</source>
-        <translation type="vanished">Точка и запятая в качестве десятичных разделителей</translation>
-    </message>
-    <message>
-        <source>Dot as thousands separator</source>
-        <translation type="vanished">Точка как разделитель тысяч</translation>
-    </message>
-    <message>
-        <source>Only dot as decimal separator</source>
-        <translation type="vanished">Только точка в качестве десятичного разделителя</translation>
-    </message>
-    <message>
-        <source>Uncategorized</source>
-        <translation type="vanished">Без категорий</translation>
-    </message>
-    <message>
-        <source>hexadecimal</source>
-        <translation type="vanished">шестнадцатеричное</translation>
-    </message>
-    <message>
-        <source>octal</source>
-        <translation type="vanished">восьмеричное</translation>
-    </message>
-    <message>
-        <source>decimal</source>
-        <translation type="vanished">десятеричное</translation>
-    </message>
-    <message>
-        <source>duodecimal</source>
-        <translation type="vanished">двенадцатеричное</translation>
-    </message>
-    <message>
-        <source>binary</source>
-        <translation type="vanished">двоичное</translation>
-    </message>
-    <message>
-        <source>roman</source>
-        <translation type="vanished">римское число</translation>
-    </message>
-    <message>
-        <source>bijective</source>
-        <translation type="vanished">биективное</translation>
-    </message>
-    <message>
-        <source>sexagesimal</source>
-        <translation type="vanished">шестидесятеричное</translation>
-    </message>
-    <message>
-        <source>latitude</source>
-        <translation type="vanished">широта</translation>
-    </message>
-    <message>
-        <source>longitude</source>
-        <translation type="vanished">долгота</translation>
-    </message>
-    <message>
-        <source>time</source>
-        <translation type="vanished">время</translation>
-    </message>
-    <message>
-        <source>bases</source>
-        <translation type="vanished">основания</translation>
-    </message>
-    <message>
-        <source>calendars</source>
-        <translation type="vanished">календари</translation>
-    </message>
-    <message>
-        <source>rectangular</source>
-        <translation type="vanished">прямоугоная</translation>
-    </message>
-    <message>
-        <source>cartesian</source>
-        <translation type="vanished">декартова</translation>
-    </message>
-    <message>
-        <source>exponential</source>
-        <translation type="vanished">экспоненциальная</translation>
-    </message>
-    <message>
-        <source>polar</source>
-        <translation type="vanished">полярная</translation>
-    </message>
-    <message>
-        <source>angle</source>
-        <translation type="vanished">угловая</translation>
-    </message>
-    <message>
-        <source>phasor</source>
-        <translation type="vanished">фазовая</translation>
-    </message>
-    <message>
-        <source>optimal</source>
-        <translation type="vanished">оптимально</translation>
-    </message>
-    <message>
-        <source>base</source>
-        <translation type="vanished">основание</translation>
-    </message>
-    <message>
-        <source>mixed</source>
-        <translation type="vanished">смешано</translation>
-    </message>
-    <message>
-        <source>fraction</source>
-        <translation type="vanished">дробь</translation>
-    </message>
-    <message>
-        <source>factors</source>
-        <translation type="vanished">множители</translation>
-    </message>
-    <message>
-        <source>partial fraction</source>
-        <translation type="vanished">частичная дробь</translation>
-    </message>
-    <message>
-        <source>factorize</source>
-        <translation type="vanished">разложить на множители</translation>
-    </message>
-    <message>
-        <source>expand</source>
-        <translation type="vanished">раскрывать</translation>
-    </message>
-    <message>
-        <source>hexadecimal number</source>
-        <translation type="vanished">шестнадцатеричное число</translation>
-    </message>
-    <message>
-        <source>octal number</source>
-        <translation type="vanished">восьмеричное число</translation>
-    </message>
-    <message>
-        <source>decimal number</source>
-        <translation type="vanished">десятичное число</translation>
-    </message>
-    <message>
-        <source>duodecimal number</source>
-        <translation type="vanished">двенадцатеричное число</translation>
-    </message>
-    <message>
-        <source>binary number</source>
-        <translation type="vanished">двоичное число</translation>
-    </message>
-    <message>
-        <source>roman numerals</source>
-        <translation type="vanished">римские цифры</translation>
-    </message>
-    <message>
-        <source>bijective base-26</source>
-        <translation type="vanished">биективное основание-26</translation>
-    </message>
-    <message>
-        <source>sexagesimal number</source>
-        <translation type="vanished">шестидесятеричное число</translation>
-    </message>
-    <message>
-        <source>32-bit floating point</source>
-        <translation type="vanished">32-битное с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>64-bit floating point</source>
-        <translation type="vanished">64-битное с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>16-bit floating point</source>
-        <translation type="vanished">16-битное с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>80-bit (x86) floating point</source>
-        <translation type="vanished">80-битное (x86) с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>128-bit floating point</source>
-        <translation type="vanished">128-битное с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>time format</source>
-        <translation type="vanished">формат времени</translation>
-    </message>
-    <message>
-        <source>number bases</source>
-        <translation type="vanished">основания систем счисления</translation>
-    </message>
-    <message>
-        <source>optimal unit</source>
-        <translation type="vanished">оптимальные единицы измерения</translation>
-    </message>
-    <message>
-        <source>base units</source>
-        <translation type="vanished">основные единицы измерения</translation>
-    </message>
-    <message>
-        <source>mixed units</source>
-        <translation type="vanished">смешанные единицы</translation>
-    </message>
-    <message>
-        <source>expanded partial fractions</source>
-        <translation type="vanished">расширенные дробные числа</translation>
-    </message>
-    <message>
-        <source>complex rectangular form</source>
-        <translation type="vanished">прямоугольная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>complex exponential form</source>
-        <translation type="vanished">экспоненциальная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>complex polar form</source>
-        <translation type="vanished">полярная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>complex cis form</source>
-        <translation type="vanished">сисоидная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>complex angle notation</source>
-        <translation type="vanished">комплексные числа в обозначении угла</translation>
-    </message>
-    <message>
-        <source>complex phasor notation</source>
-        <translation type="vanished">Комплексные числа в обозначении вектора</translation>
-    </message>
-    <message>
-        <source>UTC time zone</source>
-        <translation type="vanished">Часовой пояс UTC</translation>
-    </message>
-    <message>
-        <source>number base %s</source>
-        <translation type="vanished">основание системы счисления %s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Inactive</source>
-        <translation type="vanished">Неактивный</translation>
-    </message>
-    <message>
-        <source>Retrieves data from the %s data set for a given object and property. If &quot;info&quot; is typed as property, a dialog window will pop up with all properties of the object.</source>
-        <translation type="vanished">Извлекает данные из набора данных %s для заданного объекта и свойства. Если «инфо» введено как свойство, появится диалоговое окно со всеми свойствами объекта.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Example:</source>
-        <translation type="vanished">Пример:</translation>
-    </message>
-    <message>
-        <source>Arguments</source>
-        <translation type="vanished">Аргументы</translation>
-    </message>
-    <message>
-        <source>optional</source>
-        <extracomment>optional argument</extracomment>
-        <translation type="vanished">необязательный</translation>
-    </message>
-    <message>
-        <source>default: </source>
-        <extracomment>argument default, in description</extracomment>
-        <translation type="vanished">по умолчанию: </translation>
-    </message>
-    <message>
-        <source>Requirement</source>
-        <translation type="vanished">Требование</translation>
-    </message>
-    <message>
-        <source>key</source>
-        <extracomment>indicating that the property is a data set key</extracomment>
-        <translation type="vanished">ключ</translation>
-    </message>
-    <message>
-        <source>Acti_vate</source>
-        <translation type="vanished">Акти_вировать</translation>
-    </message>
-    <message>
-        <source>a previous result</source>
-        <translation type="vanished">предыдущий результат</translation>
-    </message>
-    <message>
-        <source>matrix</source>
-        <translation type="vanished">матрица</translation>
-    </message>
-    <message>
-        <source>vector</source>
-        <translation type="vanished">вектор</translation>
-    </message>
-    <message>
-        <source>positive</source>
-        <translation type="vanished">положительное</translation>
-    </message>
-    <message>
-        <source>non-positive</source>
-        <translation type="vanished">не положительное</translation>
-    </message>
-    <message>
-        <source>negative</source>
-        <translation type="vanished">отрицательное</translation>
-    </message>
-    <message>
-        <source>non-negative</source>
-        <translation type="vanished">неотрицательное</translation>
-    </message>
-    <message>
-        <source>non-zero</source>
-        <translation type="vanished">ненулевое</translation>
-    </message>
-    <message>
-        <source>boolean</source>
-        <translation type="vanished">логическое</translation>
-    </message>
-    <message>
-        <source>integer</source>
-        <translation type="vanished">целое</translation>
-    </message>
-    <message>
-        <source>rational</source>
-        <translation type="vanished">рациональное</translation>
-    </message>
-    <message>
-        <source>real</source>
-        <translation type="vanished">вещественное</translation>
-    </message>
-    <message>
-        <source>complex</source>
-        <translation type="vanished">комплексное</translation>
-    </message>
-    <message>
-        <source>number</source>
-        <translation type="vanished">число</translation>
-    </message>
-    <message>
-        <source>(not matrix)</source>
-        <translation type="vanished">(не матрица)</translation>
-    </message>
-    <message>
-        <source>unknown</source>
-        <translation type="vanished">неизвестное</translation>
-    </message>
-    <message>
-        <source>default assumptions</source>
-        <translation type="vanished">предположения по умолчанию</translation>
-    </message>
-    <message>
-        <source>Variable does not exist anymore.</source>
-        <translation type="vanished">Переменной больше не существует.</translation>
-    </message>
-    <message>
-        <source>Data Retrieval Function</source>
-        <translation type="vanished">Функция поиска данных</translation>
-    </message>
-    <message>
-        <source>Insert function</source>
-        <translation type="vanished">Вставить функцию</translation>
-    </message>
-    <message>
-        <source>Insert function (dialog)</source>
-        <translation type="vanished">Вставить функцию (диаорг)</translation>
-    </message>
-    <message>
-        <source>Insert variable</source>
-        <translation type="vanished">Вставить переменную</translation>
-    </message>
-    <message>
-        <source>Insert unit</source>
-        <translation type="vanished">Вставить единицу измерения</translation>
-    </message>
-    <message>
-        <source>Insert text</source>
-        <translation type="vanished">Вставить текст</translation>
-    </message>
-    <message>
-        <source>Insert date</source>
-        <translation type="vanished">Вставить дату</translation>
-    </message>
-    <message>
-        <source>Insert vector</source>
-        <translation type="vanished">Вставить вектор</translation>
-    </message>
-    <message>
-        <source>Insert matrix</source>
-        <translation type="vanished">Вставить матрицу</translation>
-    </message>
-    <message>
-        <source>Insert smart parentheses</source>
-        <translation type="vanished">Вставить умные скобки</translation>
-    </message>
-    <message>
-        <source>Convert to unit</source>
-        <translation type="vanished">Преобразовать к единице измерения</translation>
-    </message>
-    <message>
-        <source>Convert to unit (entry)</source>
-        <translation type="vanished">Преобразовать к единице измерения (запись)</translation>
-    </message>
-    <message>
-        <source>Convert to optimal unit</source>
-        <translation type="vanished">Преобразовать в оптимальную единицу измерения</translation>
-    </message>
-    <message>
-        <source>Convert to base units</source>
-        <translation type="vanished">Преобразовать в базовые единицы измерения</translation>
-    </message>
-    <message>
-        <source>Convert to optimal prefix</source>
-        <translation type="vanished">Преобразовать в оптимальный префикс</translation>
-    </message>
-    <message>
-        <source>Convert to number base</source>
-        <translation type="vanished">Преобразовать к основанию систем счисления</translation>
-    </message>
-    <message>
-        <source>Factorize result</source>
-        <translation type="vanished">Разложить результат на множители</translation>
-    </message>
-    <message>
-        <source>Expand result</source>
-        <translation type="vanished">Развернуть результат</translation>
-    </message>
-    <message>
-        <source>Expand partial fractions</source>
-        <translation type="vanished">Развернуть частичные дроби</translation>
-    </message>
-    <message>
-        <source>RPN: down</source>
-        <translation type="vanished">ПОЛИЗ: вниз</translation>
-    </message>
-    <message>
-        <source>RPN: up</source>
-        <translation type="vanished">ПОЛИЗ: вверх</translation>
-    </message>
-    <message>
-        <source>RPN: swap</source>
-        <translation type="vanished">ПОЛИЗ: обменять</translation>
-    </message>
-    <message>
-        <source>RPN: copy</source>
-        <translation type="vanished">ПОЛИЗ: копировать</translation>
-    </message>
-    <message>
-        <source>RPN: lastx</source>
-        <translation type="vanished">ПОЛИЗ: последний x</translation>
-    </message>
-    <message>
-        <source>RPN: delete register</source>
-        <translation type="vanished">ПОЛИЗ: удалить</translation>
-    </message>
-    <message>
-        <source>RPN: clear stack</source>
-        <translation type="vanished">ПОЛИЗ: очистить стек</translation>
-    </message>
-    <message>
-        <source>Load meta mode</source>
-        <translation type="vanished">Загрузить мета-режим</translation>
-    </message>
-    <message>
-        <source>Set expression base</source>
-        <translation type="vanished">Установить основание для выражения</translation>
-    </message>
-    <message>
-        <source>Set result base</source>
-        <translation type="vanished">Установить основание для результата</translation>
-    </message>
-    <message>
-        <source>Toggle exact mode</source>
-        <translation type="vanished">В(ы)ключить точный режим</translation>
-    </message>
-    <message>
-        <source>Set angle unit to degrees</source>
-        <translation type="vanished">Установить угловую единицу измерения в градусы</translation>
-    </message>
-    <message>
-        <source>Set angle unit to radians</source>
-        <translation type="vanished">Установить угловую единицу измерения в радианы</translation>
-    </message>
-    <message>
-        <source>Set angle unit to gradians</source>
-        <translation type="vanished">Установить угловую единицу измерения в грады</translation>
-    </message>
-    <message>
-        <source>Toggle simple fractions</source>
-        <translation type="vanished">В(ы)ключить простые дроби</translation>
-    </message>
-    <message>
-        <source>Toggle mixed fractions</source>
-        <translation type="vanished">В(ы)ключить смешанные дроби</translation>
-    </message>
-    <message>
-        <source>Toggle scientific notation</source>
-        <translation type="vanished">В(ы)ключить научную запись</translation>
-    </message>
-    <message>
-        <source>Toggle simple notation</source>
-        <translation type="vanished">В(ы)ключить простую запись</translation>
-    </message>
-    <message>
-        <source>Toggle RPN mode</source>
-        <translation type="vanished">В(ы)ключить режим ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>Toggle calculate as you type</source>
-        <translation type="vanished">В(ы)ключить режим расчёта по мере ввода</translation>
-    </message>
-    <message>
-        <source>Toggle programming keypad</source>
-        <translation type="vanished">В(ы)ключить клавиатуру программирования</translation>
-    </message>
-    <message>
-        <source>Show keypad</source>
-        <translation type="vanished">Показать клавиатура</translation>
-    </message>
-    <message>
-        <source>Show history</source>
-        <translation type="vanished">Показать историю</translation>
-    </message>
-    <message>
-        <source>Search history</source>
-        <translation type="vanished">Искать в истории</translation>
-    </message>
-    <message>
-        <source>Show conversion</source>
-        <translation type="vanished">Показать панель преобразования</translation>
-    </message>
-    <message>
-        <source>Show RPN stack</source>
-        <translation type="vanished">Показать стек ПОЛИЗ</translation>
-    </message>
-    <message>
-        <source>Manage variables</source>
-        <translation type="vanished">Управление переменными</translation>
-    </message>
-    <message>
-        <source>Manage functions</source>
-        <translation type="vanished">Управление функциями</translation>
-    </message>
-    <message>
-        <source>Manage data sets</source>
-        <translation type="vanished">Управление наборами данных</translation>
-    </message>
-    <message>
-        <source>New variable</source>
-        <translation type="vanished">Новая переменная</translation>
-    </message>
-    <message>
-        <source>New function</source>
-        <translation type="vanished">Новая функция</translation>
-    </message>
-    <message>
-        <source>Open plot functions/data</source>
-        <translation type="vanished">Открыть график функций/данных</translation>
-    </message>
-    <message>
-        <source>Open convert number bases</source>
-        <translation type="vanished">Открыть преобразование между основаниями систем счисления</translation>
-    </message>
-    <message>
-        <source>Open floating point conversion</source>
-        <translation type="vanished">Открыть окно преобразования чисел с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>Open calender conversion</source>
-        <translation type="vanished">Открыть окно преобразования календарей</translation>
-    </message>
-    <message>
-        <source>Open percentage calculation tool</source>
-        <translation type="vanished">Открыть окно инструмента расчёта процентов</translation>
-    </message>
-    <message>
-        <source>Open periodic table</source>
-        <translation type="vanished">Открыть окно с периодической таблицей</translation>
-    </message>
-    <message>
-        <source>Update exchange rates</source>
-        <translation type="vanished">Обновить курсы валют</translation>
-    </message>
-    <message>
-        <source>Copy result</source>
-        <translation type="vanished">Скопировать результат</translation>
-    </message>
-    <message>
-        <source>Insert result</source>
-        <translation type="vanished">Вставить результат</translation>
-    </message>
-    <message>
-        <source>Save result image</source>
-        <translation type="vanished">Сохранить изображение с результатом</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Справка</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">В_ыход</translation>
-    </message>
-    <message>
-        <source>Toggle chain mode</source>
-        <translation type="vanished">В(ы)ключить режим цепочки</translation>
-    </message>
-    <message>
-        <source>Toggle keep above</source>
-        <translation type="vanished">Поддерживать поверх других</translation>
-    </message>
-    <message>
-        <source>Show/hide completion</source>
-        <translation type="vanished">Показать/скрыть завершение</translation>
-    </message>
-    <message>
-        <source>Perform completion (activate first item)</source>
-        <translation type="vanished">Выполнять завершение (активировать первый пункт)</translation>
-    </message>
-    <message>
-        <source>Prefixes</source>
-        <translation type="vanished">Префиксы</translation>
-    </message>
-    <message>
-        <source>No Prefix</source>
-        <translation type="vanished">Без префикса</translation>
-    </message>
-    <message>
-        <source>Optimal Prefix</source>
-        <translation type="vanished">Оптимальный префикс</translation>
-    </message>
-    <message>
-        <source>Prefix</source>
-        <translation type="vanished">Префикс</translation>
-    </message>
-    <message>
-        <source>Complex angle/phasor notation</source>
-        <translation type="vanished">Комплексные числа в обозначении угла/вектора</translation>
-    </message>
-    <message>
-        <source>Number bases</source>
-        <translation type="vanished">Основания систем счисления</translation>
-    </message>
-    <message>
-        <source>Base units</source>
-        <translation type="vanished">Основные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Binary number</source>
-        <translation type="vanished">Двоичное число</translation>
-    </message>
-    <message>
-        <source>Calendars</source>
-        <translation type="vanished">Календари</translation>
-    </message>
-    <message>
-        <source>Complex cis form</source>
-        <translation type="vanished">Сисоидная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Decimal number</source>
-        <translation type="vanished">Десятичное число</translation>
-    </message>
-    <message>
-        <source>Duodecimal number</source>
-        <translation type="vanished">Двенадцатеричное число</translation>
-    </message>
-    <message>
-        <source>Complex exponential form</source>
-        <translation type="vanished">Экспоненциальная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Factors</source>
-        <translation type="vanished">Множители</translation>
-    </message>
-    <message>
-        <source>16-bit floating point binary format</source>
-        <translation type="vanished">16-битное в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>32-bit floating point binary format</source>
-        <translation type="vanished">32-битное в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>64-bit floating point binary format</source>
-        <translation type="vanished">64-битное в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>80-bit (x86) floating point binary format</source>
-        <translation type="vanished">80-битное (x86) в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>128-bit floating point binary format</source>
-        <translation type="vanished">128-битное в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>Hexadecimal number</source>
-        <translation type="vanished">Шестнадцатеричное число</translation>
-    </message>
-    <message>
-        <source>Latitude</source>
-        <translation type="vanished">Широта</translation>
-    </message>
-    <message>
-        <source>Longitude</source>
-        <translation type="vanished">Долгота</translation>
-    </message>
-    <message>
-        <source>Mixed units</source>
-        <translation type="vanished">Смешанные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Octal number</source>
-        <translation type="vanished">Восьмеричное число</translation>
-    </message>
-    <message>
-        <source>Optimal units</source>
-        <translation type="vanished">Оптимальные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Expanded partial fractions</source>
-        <translation type="vanished">Расширенные дробные числа</translation>
-    </message>
-    <message>
-        <source>Complex polar form</source>
-        <translation type="vanished">Полярная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Complex rectangular form</source>
-        <translation type="vanished">Прямоугольная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Sexagesimal number</source>
-        <translation type="vanished">Шестидесятеричное число</translation>
-    </message>
-    <message>
-        <source>and</source>
-        <translation type="vanished">и</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation type="vanished">или</translation>
-    </message>
-    <message>
-        <source>undefined</source>
-        <translation type="vanished">не определено</translation>
-    </message>
-    <message>
-        <source>result is too long
-see history</source>
-        <translation type="vanished">результат слишком длинный
-смотрите историю</translation>
-    </message>
-    <message>
-        <source>calculation was aborted</source>
-        <translation type="vanished">расчёт был прерван</translation>
-    </message>
-    <message>
-        <source>RPN Register Moved</source>
-        <translation type="vanished">Регистр ПОЛИЗ перемещён</translation>
-    </message>
-    <message>
-        <source>RPN Operation</source>
-        <translation type="vanished">ПОЛИЗ операция</translation>
-    </message>
-    <message>
-        <source>Processing…</source>
-        <translation type="vanished">Обработка…</translation>
-    </message>
-    <message>
-        <source>result processing was aborted</source>
-        <translation type="vanished">обработка результатов была прервана</translation>
-    </message>
-    <message>
-        <source>Factorizing…</source>
-        <translation type="vanished">Факторизация…</translation>
-    </message>
-    <message>
-        <source>Expanding partial fractions…</source>
-        <translation type="vanished">Расширение дробных чисел…</translation>
-    </message>
-    <message>
-        <source>Expanding…</source>
-        <translation type="vanished">Расширение…</translation>
-    </message>
-    <message>
-        <source>Calculating…</source>
-        <translation type="vanished">Расчёт…</translation>
-    </message>
-    <message>
-        <source>Converting…</source>
-        <translation type="vanished">Преобразование…</translation>
-    </message>
-    <message>
-        <source>Fetching exchange rates.</source>
-        <translation type="vanished">Получение курсов валют.</translation>
-    </message>
-    <message>
-        <source>Time zone parsing failed.</source>
-        <translation type="vanished">Не удалось выполнить синтаксический анализ часового пояса.</translation>
-    </message>
-    <message>
-        <source>Keep open</source>
-        <translation type="vanished">Держать открытым</translation>
-    </message>
-    <message>
-        <source>Enter</source>
-        <extracomment>RPN Enter (calculate and add to stack)</extracomment>
-        <translation type="vanished">Ввод</translation>
-    </message>
-    <message>
-        <source>C_alculate</source>
-        <translation type="vanished">_Рассчитать</translation>
-    </message>
-    <message>
-        <source>Apply to Stack</source>
-        <translation type="vanished">Применить к стеку</translation>
-    </message>
-    <message>
-        <source>Argument</source>
-        <translation type="vanished">Аргумент</translation>
-    </message>
-    <message>
-        <source>True</source>
-        <translation type="vanished">Истина</translation>
-    </message>
-    <message>
-        <source>False</source>
-        <translation type="vanished">Ложь</translation>
-    </message>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Инфо</translation>
-    </message>
-    <message>
-        <source>Edit Unit (global)</source>
-        <translation type="vanished">Изменить единицу измерения (глобальную)</translation>
-    </message>
-    <message>
-        <source>New Unit</source>
-        <translation type="vanished">Новая единица измерения</translation>
-    </message>
-    <message>
-        <source>Empty name field.</source>
-        <translation type="vanished">Введите имя поля</translation>
-    </message>
-    <message>
-        <source>A variable or unit with the same name already exists.
-Do you want to overwrite it?</source>
-        <extracomment>unit with the same name exists -- overwrite or open the dialog again</extracomment>
-        <translation type="vanished">Переменная или единица измерения с таким именем уже существует.
-Вы хотите её перезаписать?</translation>
-    </message>
-    <message>
-        <source>Base unit does not exist.</source>
-        <translation type="vanished">Основная единица измерения не существует</translation>
-    </message>
-    <message>
-        <source>Edit Function (global)</source>
-        <translation type="vanished">Изменить функцию (глобальную)</translation>
-    </message>
-    <message>
-        <source>New Function</source>
-        <translation type="vanished">Новая функция</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation type="vanished">Да</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Нет</translation>
-    </message>
-    <message>
-        <source>Empty expression field.</source>
-        <translation type="vanished">Пустое поле выражения.</translation>
-    </message>
-    <message>
-        <source>A function with the same name already exists.
-Do you want to overwrite the function?</source>
-        <extracomment>function with the same name exists -- overwrite or open the dialog againdataset with the same name exists -- overwrite or open the dialog again</extracomment>
-        <translation type="vanished">Функция с таким именем уже существует.
-Хотите перезаписать функцию?</translation>
-    </message>
-    <message>
-        <source>Unit does not exist</source>
-        <translation type="vanished">Единица измерения не существует</translation>
-    </message>
-    <message>
-        <source>Edit Unknown Variable (global)</source>
-        <translation type="vanished">Изменить переменную неизвестного (глобальную)</translation>
-    </message>
-    <message>
-        <source>New Unknown Variable</source>
-        <translation type="vanished">Новая переменная неизвестного</translation>
-    </message>
-    <message>
-        <source>An unit or variable with the same name already exists.
-Do you want to overwrite it?</source>
-        <extracomment>unknown with the same name exists -- overwrite or open dialog againvariable with the same name exists -- overwrite or open dialog again</extracomment>
-        <translation type="vanished">Единица измерения или переменная или  с таким именем уже существует.
-Вы хотите её перезаписать?</translation>
-    </message>
-    <message>
-        <source>Edit Variable (global)</source>
-        <translation type="vanished">Изменить переменную (глобальную)</translation>
-    </message>
-    <message>
-        <source>New Variable</source>
-        <translation type="vanished">Новая переменная</translation>
-    </message>
-    <message>
-        <source>Empty value field.</source>
-        <translation type="vanished">Пустое поле значения.</translation>
-    </message>
-    <message>
-        <source>Edit Vector</source>
-        <translation type="vanished">Изменить вектор</translation>
-    </message>
-    <message>
-        <source>Edit Vector (global)</source>
-        <translation type="vanished">Изменить вектор (глобальный)</translation>
-    </message>
-    <message>
-        <source>New Vector</source>
-        <translation type="vanished">Новый вектор</translation>
-    </message>
-    <message>
-        <source>Edit Matrix (global)</source>
-        <translation type="vanished">Изменить матрицу (глобальную)</translation>
-    </message>
-    <message>
-        <source>New Matrix</source>
-        <translation type="vanished">Новая матрица</translation>
-    </message>
-    <message>
-        <source>Vector Result</source>
-        <translation type="vanished">Векторный результат</translation>
-    </message>
-    <message>
-        <source>Matrix Result</source>
-        <translation type="vanished">Матричный результат</translation>
-    </message>
-    <message>
-        <source>New Data Object</source>
-        <translation type="vanished">Новый объект данных</translation>
-    </message>
-    <message>
-        <source>text</source>
-        <translation type="vanished">текст</translation>
-    </message>
-    <message>
-        <source>approximate</source>
-        <translation type="vanished">приблизительно</translation>
-    </message>
-    <message>
-        <source>Edit Data Set (global)</source>
-        <translation type="vanished">Изменить набор данных (глобальный)</translation>
-    </message>
-    <message>
-        <source>New Data Set</source>
-        <translation type="vanished">Новый набор данных</translation>
-    </message>
-    <message>
-        <source>info</source>
-        <translation type="vanished">инфо</translation>
-    </message>
-    <message>
-        <source>Property</source>
-        <translation type="vanished">Свойство</translation>
-    </message>
-    <message>
-        <source>No file name entered.</source>
-        <translation type="vanished">Имя файла не введено.</translation>
-    </message>
-    <message>
-        <source>No delimiter selected.</source>
-        <translation type="vanished">Разделитель не выбран.</translation>
-    </message>
-    <message>
-        <source>Could not import from file 
-%s</source>
-        <translation type="vanished">Не удалось импортировать из файла 
-%s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>No variable name entered.</source>
-        <translation type="vanished">Имя переменной не введено.</translation>
-    </message>
-    <message>
-        <source>No known variable with entered name found.</source>
-        <translation type="vanished">Не найдено известных переменных с указанным именем.</translation>
-    </message>
-    <message>
-        <source>Could not export to file 
-%s</source>
-        <translation type="vanished">Не удалось экспортировать в файл 
-%s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>My Variables</source>
-        <translation type="vanished">Мои переменные</translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t write definitions</source>
-        <translation type="vanished">Не удалось записать определения</translation>
-    </message>
-    <message>
-        <source>Preset</source>
-        <translation type="vanished">Предустановка</translation>
-    </message>
-    <message>
-        <source>Abort</source>
-        <translation type="vanished">Прервать</translation>
-    </message>
-    <message>
-        <source>Undo</source>
-        <translation type="vanished">Отменить</translation>
-    </message>
-    <message>
-        <source>Redo</source>
-        <translation type="vanished">Повторить</translation>
-    </message>
-    <message>
-        <source>Completion Mode</source>
-        <translation type="vanished">Режим завершения</translation>
-    </message>
-    <message>
-        <source>Limited strict completion</source>
-        <translation type="vanished">Ограниченное строгое завершение</translation>
-    </message>
-    <message>
-        <source>Strict completion</source>
-        <translation type="vanished">Строгое завершение</translation>
-    </message>
-    <message>
-        <source>Limited full completion</source>
-        <translation type="vanished">Ограниченное полное завершение</translation>
-    </message>
-    <message>
-        <source>Full completion</source>
-        <translation type="vanished">Полное завершение</translation>
-    </message>
-    <message>
-        <source>No completion</source>
-        <translation type="vanished">Без завершения</translation>
-    </message>
-    <message>
-        <source>Delayed completion</source>
-        <translation type="vanished">Отложенное завершение</translation>
-    </message>
-    <message>
-        <source>Customize completion…</source>
-        <translation type="vanished">Настроить завершение…</translation>
-    </message>
-    <message>
-        <source>Save Mode</source>
-        <translation type="vanished">Сохранить режим</translation>
-    </message>
-    <message>
-        <source>Preset mode cannot be overwritten.</source>
-        <translation type="vanished">Предустановленный режим нельзя перезаписать.</translation>
-    </message>
-    <message>
-        <source>Delete Mode</source>
-        <translation type="vanished">Удалить режим</translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t write preferences to
-%s</source>
-        <translation type="vanished">Не удалось записать настройки в
-%s</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>never</source>
-        <translation type="vanished">никогда</translation>
-    </message>
-    <message>
-        <source>ask</source>
-        <translation type="vanished">спросить</translation>
-    </message>
-    <message numerus="yes">
-        <source>%i day</source>
-        <translation type="vanished">
-            <numerusform>%i день</numerusform>
-            <numerusform>%i дня</numerusform>
-            <numerusform>%i дней</numerusform>
-        </translation>
-        <extra-po-flags>c-format</extra-po-flags>
-        <extra-po-msgid_plural>%i days</extra-po-msgid_plural>
-    </message>
-    <message>
-        <source>Copied</source>
-        <extracomment>Result was copied</extracomment>
-        <translation type="vanished">Скопировано</translation>
-    </message>
-    <message>
-        <source>log10 function not found.</source>
-        <translation type="vanished">Функция log10 не найдена.</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Поиск</translation>
-    </message>
-    <message>
-        <source>_Search</source>
-        <translation type="vanished">Пои_ск</translation>
-    </message>
-    <message>
-        <source>Remove Bookmark</source>
-        <translation type="vanished">Удалить закладку</translation>
-    </message>
-    <message>
-        <source>Add Bookmark</source>
-        <translation type="vanished">Добавить закладку</translation>
-    </message>
-    <message>
-        <source>A bookmark with the selected name already exists.
-Do you want to overwrite it?</source>
-        <translation type="vanished">Закладка с таким именем уже существует.
-Вы хотите её перезаписать?</translation>
-    </message>
-    <message>
-        <source>No items found</source>
-        <translation type="vanished">Ничего не найдено</translation>
-    </message>
-    <message>
-        <source>Select date</source>
-        <translation type="vanished">Выберать дату</translation>
-    </message>
-    <message>
-        <source>Rectangular form</source>
-        <translation type="vanished">Прямоугольная форма</translation>
-    </message>
-    <message>
-        <source>Exponential form</source>
-        <translation type="vanished">Экспоненциальная форма</translation>
-    </message>
-    <message>
-        <source>Polar form</source>
-        <translation type="vanished">Полярная форма</translation>
-    </message>
-    <message>
-        <source>Angle/phasor notation</source>
-        <translation type="vanished">В обозначении угла/вектора</translation>
-    </message>
-    <message>
-        <source>Optimal unit</source>
-        <translation type="vanished">Оптимальная единица измерения</translation>
-    </message>
-    <message>
-        <source>Optimal prefix</source>
-        <translation type="vanished">Оптимальный префикс</translation>
-    </message>
-    <message>
-        <source>All functions</source>
-        <translation type="vanished">Все функции</translation>
-    </message>
-    <message>
-        <source>All variables</source>
-        <translation type="vanished">Все переменные</translation>
-    </message>
-    <message>
-        <source>Select definitions file</source>
-        <translation type="vanished">Выбрать файл определений</translation>
-    </message>
-    <message>
-        <source>_Import</source>
-        <translation type="vanished">_Импорт</translation>
-    </message>
-    <message>
-        <source>Could not copy %s to %s.</source>
-        <translation type="vanished">С удалось скопировать %s в %s.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Could not read %s.</source>
-        <translation type="vanished">С удалось прочитать %s.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Could not copy file to %s.</source>
-        <translation type="vanished">С удалось скопировать файл в %s.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Unsupported base.</source>
-        <translation type="vanished">Неподдерживаемое основание.</translation>
-    </message>
-    <message>
-        <source>The selected Chinese year does not exist.</source>
-        <translation type="vanished">Выбранный китайский год не существует.</translation>
-    </message>
-    <message>
-        <source>Conversion to Gregorian calendar failed.</source>
-        <translation type="vanished">Преобразование в григорианский календарь не удалось.</translation>
-    </message>
-    <message>
-        <source>Calendar conversion failed for: %s.</source>
-        <translation type="vanished">Ошибка преобразования календаря для: %s.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Gnuplot was not found.</source>
-        <translation type="vanished">Программа Gnuplot не найдена.</translation>
-    </message>
-    <message>
-        <source>%s (%s) needs to be installed separately, and found in the executable search path, for plotting to work.</source>
-        <translation type="vanished">%s (%s) должен быть установлен отдельно и находиться по переменной окружения PATH, чтобы график работал.</translation>
-        <extra-po-flags>c-format</extra-po-flags>
-    </message>
-    <message>
-        <source>Select file to save PNG image to</source>
-        <translation type="vanished">Выбрать файл для сохранения изображения в формате PNG</translation>
-    </message>
-    <message>
-        <source>Allowed File Types</source>
-        <translation type="vanished">Разрешить все типы файлов</translation>
-    </message>
-    <message>
-        <source>All Files</source>
-        <translation type="vanished">Все файлы</translation>
-    </message>
-    <message>
-        <source>Cannot delete unit as it is needed by other units.</source>
-        <extracomment>do not delete units that are used by other units</extracomment>
-        <translation type="vanished">Невозможно удалить объект, так как он нужен другим объектам.</translation>
-    </message>
-    <message>
-        <source>none</source>
-        <translation type="vanished">ничто</translation>
-    </message>
-    <message>
-        <source>result is too long</source>
-        <translation type="vanished">результат слишком длинный</translation>
-    </message>
-    <message>
-        <source>translator-credits</source>
-        <translation type="vanished">Damir Islamov &lt;damir@secretlaboratory.ru&gt;</translation>
-    </message>
-    <message>
-        <source>Mode not found.</source>
-        <translation type="vanished">Режим не найден.</translation>
-    </message>
-    <message>
-        <source>Elements (in horizontal order)</source>
-        <translation type="vanished">Компоненты (в горизонтальном порядке)</translation>
-    </message>
-    <message>
-        <source>Select file to import</source>
-        <translation type="vanished">Выбрать файл для импорта</translation>
-    </message>
-    <message>
-        <source>_Open</source>
-        <translation type="vanished">_Открыть</translation>
-    </message>
-    <message>
-        <source>Select file to export to</source>
-        <translation type="vanished">Выбрать файл, в который экспортировать</translation>
-    </message>
-    <message>
-        <source>A conflicting object with the same name exists. If you proceed and save changes, the conflicting object will be overwritten or deactivated.
-Do you want to proceed?</source>
-        <translation type="vanished">Существует конфликтующий объект с таким же именем. Если вы продолжите и сохраните изменения, конфликтующий объект будет перезаписан или деактивирован.
-Хотите продолжить?</translation>
-    </message>
-    <message>
-        <source>Set key combination</source>
-        <translation type="vanished">Назначить комбинацию клавиш</translation>
-    </message>
-    <message>
-        <source>Press the key combination you wish to use for the action
-(press Escape to cancel).</source>
-        <extracomment>Make the line reasonably long, but not to short (at least around 40 characters)</extracomment>
-        <translation type="vanished">Нажмите комбинацию клавиш, которую хотите использовать для действия
-(нажмите Escape для отмены).</translation>
-    </message>
-    <message>
-        <source>No keys</source>
-        <translation type="vanished">Нет</translation>
-    </message>
-    <message>
-        <source>Empty value.</source>
-        <translation type="vanished">Пустое значение.</translation>
-    </message>
-    <message>
-        <source>Function not found.</source>
-        <translation type="vanished">Функция не найдена.</translation>
-    </message>
-    <message>
-        <source>Variable not found.</source>
-        <translation type="vanished">Переменная не найдена.</translation>
-    </message>
-    <message>
-        <source>Unit not found.</source>
-        <translation type="vanished">Единица измерения не найдена.</translation>
-    </message>
-    <message>
-        <source>The key combination is already in use.
-Do you wish to replace the current action?</source>
-        <translation type="vanished">Комбинация клавиш уже используется.
-Вы хотите заменить текущее действие?</translation>
-    </message>
-    <message>
-        <source>Select file to export</source>
-        <translation type="vanished">Выберите файл для экспорта</translation>
-    </message>
-    <message>
-        <source>Empty expression.</source>
-        <translation type="vanished">Пустое выражение.</translation>
-    </message>
-    <message>
-        <source>Empty x variable.</source>
-        <translation type="vanished">Пустая переменная x.</translation>
-    </message>
-    <message>
-        <source>Element Data</source>
-        <translation type="vanished">Данные элемента</translation>
-    </message>
-    <message>
-        <source>Classification</source>
-        <translation type="vanished">Классификация</translation>
-    </message>
-    <message>
-        <source>Alkali Metal</source>
-        <translation type="vanished">Щелочной металл</translation>
-    </message>
-    <message>
-        <source>Alkaline-Earth Metal</source>
-        <translation type="vanished">Щелочноземельный металл</translation>
-    </message>
-    <message>
-        <source>Lanthanide</source>
-        <translation type="vanished">Лантаноид</translation>
-    </message>
-    <message>
-        <source>Actinide</source>
-        <translation type="vanished">Актиноид</translation>
-    </message>
-    <message>
-        <source>Transition Metal</source>
-        <translation type="vanished">Переходный металл</translation>
-    </message>
-    <message>
-        <source>Metal</source>
-        <translation type="vanished">Металл</translation>
-    </message>
-    <message>
-        <source>Metalloid</source>
-        <translation type="vanished">Металлоид</translation>
-    </message>
-    <message>
-        <source>Polyatomic Non-Metal</source>
-        <translation type="vanished">Многоатомный неметалл</translation>
-    </message>
-    <message>
-        <source>Diatomic Non-Metal</source>
-        <translation type="vanished">Двухатомный неметалл</translation>
-    </message>
-    <message>
-        <source>Noble Gas</source>
-        <translation type="vanished">Благородный газ</translation>
-    </message>
-    <message>
-        <source>Unknown chemical properties</source>
-        <translation type="vanished">Неизвестные химические свойства</translation>
-    </message>
-    <message>
-        <source>No unknowns in result.</source>
-        <translation type="vanished">В результате нет неизвестных.</translation>
-    </message>
-    <message>
-        <source>Set Unknowns</source>
-        <translation type="vanished">Установить неизвестные</translation>
-    </message>
-    <message>
-        <source>Copy result to clipboard</source>
-        <translation type="vanished">Скопировать результат в буфер обмена</translation>
-    </message>
-</context>
-<context>
     <name>CSVDialog</name>
     <message>
         <location filename="../src/csvdialog.cpp" line="33"/>
         <source>Import CSV File</source>
-        <translation type="unfinished">Загрузить файл формата CSV</translation>
+        <translation>Загрузить файл формата CSV</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="33"/>
         <source>Export CSV File</source>
-        <translation type="unfinished">Экспорт в файл типа CSV</translation>
+        <translation>Экспорт в файл типа CSV</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="41"/>
         <source>Current result</source>
-        <translation type="unfinished">Текущий результат</translation>
+        <translation>Текущий результат</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="44"/>
         <source>Matrix/vector variable:</source>
-        <translation type="unfinished">Матричная/векторная переменная:</translation>
+        <translation>Матричная/векторная переменная:</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="56"/>
         <source>File:</source>
-        <translation type="unfinished">Файл:</translation>
+        <translation>Файл:</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="66"/>
         <source>Import as</source>
-        <translation type="unfinished">Импортировать как</translation>
+        <translation>Импортировать как</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="70"/>
         <source>matrix</source>
-        <translation type="unfinished">матрица</translation>
+        <translation>матрица</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="72"/>
         <source>vectors</source>
-        <translation type="unfinished">векторы</translation>
+        <translation>векторы</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="75"/>
         <source>Name:</source>
-        <translation type="unfinished">Имя:</translation>
+        <translation>Имя:</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="78"/>
         <source>First row:</source>
-        <translation type="unfinished">Первая строка:</translation>
+        <translation>Первая строка:</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="82"/>
         <source>Includes headings</source>
-        <translation type="unfinished">Включает заголовки</translation>
+        <translation>Включает заголовки</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="85"/>
         <source>Delimiter:</source>
-        <translation type="unfinished">Разделитель:</translation>
+        <translation>Разделитель:</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="87"/>
         <source>Comma</source>
-        <translation type="unfinished">Запятая</translation>
+        <translation>Запятая</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="88"/>
         <source>Tabulator</source>
-        <translation type="unfinished">Табуляция</translation>
+        <translation>Табуляция</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="89"/>
         <source>Semicolon</source>
-        <translation type="unfinished">Точка с запятой</translation>
+        <translation>Точка с запятой</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="90"/>
         <source>Space</source>
-        <translation type="unfinished">Пробел</translation>
+        <translation>Пробел</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="91"/>
         <source>Other</source>
-        <translation type="unfinished">Другой</translation>
+        <translation>Другой</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="147"/>
         <source>A unit or variable with the same name already exists.
 Do you want to overwrite it?</source>
-        <translation type="unfinished">Единица измерения или переменная или  с таким именем уже существует.
-Вы хотите её перезаписать?</translation>
-    </message>
-    <message>
-        <source>An unit or variable with the same name already exists.
-Do you want to overwrite it?</source>
-        <translation type="obsolete">Единица измерения или переменная или  с таким именем уже существует.
+        <translation>Единица измерения или переменная с таким именем уже существует.
 Вы хотите её перезаписать?</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="153"/>
         <source>Could not import from file 
 %1</source>
-        <translation type="unfinished">Не удалось импортировать из файла 
+        <translation>Не удалось импортировать из файла 
 %1</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="175"/>
         <source>Could not export to file 
 %1</source>
-        <translation type="unfinished">Не удалось экспортировать в файл 
+        <translation>Не удалось экспортировать в файл 
 %1</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="147"/>
         <source>Question</source>
-        <translation type="unfinished">Вопрос</translation>
+        <translation>Вопрос</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="153"/>
         <location filename="../src/csvdialog.cpp" line="167"/>
         <location filename="../src/csvdialog.cpp" line="175"/>
         <source>Error</source>
-        <translation type="unfinished">Ошибка</translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../src/csvdialog.cpp" line="167"/>
         <source>No matrix or vector variable with the entered name was found.</source>
-        <translation type="unfinished">Матричная или векторная переменная с указанным именем не найдена.</translation>
+        <translation>Матричная или векторная переменная с указанным именем не найдена.</translation>
     </message>
 </context>
 <context>
@@ -5240,89 +132,89 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="27"/>
         <source>Calendar Conversion</source>
-        <translation type="unfinished">Преобразование календаря</translation>
+        <translation>Преобразование календаря</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="33"/>
         <location filename="../src/calendarconversiondialog.cpp" line="130"/>
         <source>Gregorian</source>
-        <translation type="unfinished">Григорианский</translation>
+        <translation>Григорианский</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="34"/>
         <location filename="../src/calendarconversiondialog.cpp" line="131"/>
         <source>Hebrew</source>
-        <translation type="unfinished">Еврейский</translation>
+        <translation>Еврейский</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="35"/>
         <location filename="../src/calendarconversiondialog.cpp" line="132"/>
         <source>Islamic (Hijri)</source>
-        <translation type="unfinished">Исламский (от Хиджры)</translation>
+        <translation>Исламский (от Хиджры)</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="36"/>
         <location filename="../src/calendarconversiondialog.cpp" line="133"/>
         <source>Persian (Solar Hijri)</source>
-        <translation type="unfinished">Иранский (Солнечная хиджра)</translation>
+        <translation>Иранский (Солнечная хиджра)</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="37"/>
         <location filename="../src/calendarconversiondialog.cpp" line="134"/>
         <source>Indian (National)</source>
-        <translation type="unfinished">Индийский (национальный)</translation>
+        <translation>Индийский (национальный)</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="38"/>
         <location filename="../src/calendarconversiondialog.cpp" line="135"/>
         <source>Chinese</source>
-        <translation type="unfinished">Китайский</translation>
+        <translation>Китайский</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="39"/>
         <location filename="../src/calendarconversiondialog.cpp" line="136"/>
         <source>Julian</source>
-        <translation type="unfinished">Юлианский</translation>
+        <translation>Юлианский</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="40"/>
         <location filename="../src/calendarconversiondialog.cpp" line="137"/>
         <source>Revised Julian (Milanković)</source>
-        <translation type="unfinished">Пересмотренный юлианский (циклы Миланковича)</translation>
+        <translation>Пересмотренный юлианский (Миланковича)</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="41"/>
         <location filename="../src/calendarconversiondialog.cpp" line="138"/>
         <source>Coptic</source>
-        <translation type="unfinished">Коптский</translation>
+        <translation>Коптский</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="42"/>
         <location filename="../src/calendarconversiondialog.cpp" line="139"/>
         <source>Ethiopian</source>
-        <translation type="unfinished">Эфиопский</translation>
+        <translation>Эфиопский</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="86"/>
         <source>The selected Chinese year does not exist.</source>
-        <translation type="unfinished">Выбранный китайский год не существует.</translation>
+        <translation>Выбранный китайский год не существует.</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="98"/>
         <source>Conversion to Gregorian calendar failed.</source>
-        <translation type="unfinished">Преобразование в григорианский календарь не удалось.</translation>
+        <translation>Преобразование в григорианский календарь не удалось.</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="143"/>
         <source>Calendar conversion failed for: %1.</source>
-        <translation type="unfinished">Ошибка преобразования календаря для: %1.</translation>
+        <translation>Ошибка преобразования календаря для: %1.</translation>
     </message>
     <message>
         <location filename="../src/calendarconversiondialog.cpp" line="86"/>
         <location filename="../src/calendarconversiondialog.cpp" line="98"/>
         <location filename="../src/calendarconversiondialog.cpp" line="143"/>
         <source>Error</source>
-        <translation type="unfinished">Ошибка</translation>
+        <translation>Ошибка</translation>
     </message>
 </context>
 <context>
@@ -5410,682 +302,578 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../src/expressionedit.cpp" line="1183"/>
         <source>Prefix:</source>
-        <translation type="unfinished">Префикс:</translation>
-    </message>
-    <message>
-        <source>Complex angle/phasor notation</source>
-        <translation type="obsolete">Комплексные числа в обозначении угла/вектора</translation>
+        <translation>Префикс:</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1241"/>
         <source>Base units</source>
-        <translation type="unfinished">Основные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Number base</source>
-        <translation type="obsolete">Основание системы счисления</translation>
-    </message>
-    <message>
-        <source>Bijective base-26</source>
-        <translation type="obsolete">Биективное основание-26</translation>
-    </message>
-    <message>
-        <source>Binary number</source>
-        <translation type="obsolete">Двоичное число</translation>
+        <translation>Основные единицы измерения</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1249"/>
         <source>Calendars</source>
-        <translation type="unfinished">Календари</translation>
-    </message>
-    <message>
-        <source>Complex cis form</source>
-        <translation type="obsolete">Сисоидная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Decimal number</source>
-        <translation type="obsolete">Десятичное число</translation>
-    </message>
-    <message>
-        <source>Duodecimal number</source>
-        <translation type="obsolete">Двенадцатеричное число</translation>
-    </message>
-    <message>
-        <source>Complex exponential form</source>
-        <translation type="obsolete">Экспоненциальная форма комплексных чисел</translation>
+        <translation>Календари</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1259"/>
         <source>Factors</source>
-        <translation type="unfinished">Множители</translation>
-    </message>
-    <message>
-        <source>16-bit floating point binary format</source>
-        <translation type="obsolete">16-битное в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>32-bit floating point binary format</source>
-        <translation type="obsolete">32-битное в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>64-bit floating point binary format</source>
-        <translation type="obsolete">64-битное в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>80-bit (x86) floating point binary format</source>
-        <translation type="obsolete">80-битное (x86) в двоичном формате с плавающей запятой</translation>
-    </message>
-    <message>
-        <source>128-bit floating point binary format</source>
-        <translation type="obsolete">128-битное в двоичном формате с плавающей запятой</translation>
+        <translation>Множители</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1271"/>
         <source>Fraction</source>
-        <translation type="unfinished">Дробь</translation>
-    </message>
-    <message>
-        <source>Hexadecimal number</source>
-        <translation type="obsolete">Шестнадцатеричное число</translation>
+        <translation>Дробь</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1275"/>
         <source>Latitude</source>
-        <translation type="unfinished">Широта</translation>
+        <translation>Широта</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1277"/>
         <source>Longitude</source>
-        <translation type="unfinished">Долгота</translation>
-    </message>
-    <message>
-        <source>Mixed units</source>
-        <translation type="obsolete">Смешанные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Octal number</source>
-        <translation type="obsolete">Восьмеричное число</translation>
-    </message>
-    <message>
-        <source>Optimal units</source>
-        <translation type="obsolete">Оптимальные единицы измерения</translation>
-    </message>
-    <message>
-        <source>Expanded partial fractions</source>
-        <translation type="obsolete">Расширенные дробные числа</translation>
-    </message>
-    <message>
-        <source>Complex polar form</source>
-        <translation type="obsolete">Полярная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Complex rectangular form</source>
-        <translation type="obsolete">Прямоугольная форма комплексных чисел</translation>
-    </message>
-    <message>
-        <source>Roman numerals</source>
-        <translation type="obsolete">Римские цифры</translation>
-    </message>
-    <message>
-        <source>Sexagesimal number</source>
-        <translation type="obsolete">Шестидесятеричное число</translation>
-    </message>
-    <message>
-        <source>Time format</source>
-        <translation type="obsolete">Формат времени</translation>
+        <translation>Долгота</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1297"/>
         <location filename="../src/expressionedit.cpp" line="2130"/>
         <source>Unicode</source>
-        <translation type="unfinished">Юникод</translation>
+        <translation>Юникод</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2160"/>
         <source>UTC time zone</source>
-        <translation type="unfinished">Часовой пояс UTC</translation>
+        <translation>Часовой пояс UTC</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1607"/>
         <source>Undo</source>
-        <translation type="unfinished">Отменить</translation>
+        <translation>Отменить</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1237"/>
         <source>Complex Angle/Phasor Notation</source>
-        <translation type="unfinished">Обозначение угла/вектора комплексных чисел</translation>
+        <translation>Обозначение угла/вектора комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1243"/>
         <source>Number Base</source>
-        <translation type="unfinished">Основание системы счисления</translation>
+        <translation>Основание системы счисления</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1245"/>
         <source>Bijective Base-26</source>
-        <translation type="unfinished">Биективное основание-26</translation>
-    </message>
-    <message>
-        <source>Binary Bumber</source>
-        <translation type="obsolete">Двоичное число</translation>
-    </message>
-    <message>
-        <source>Complex Cis Form</source>
-        <translation type="obsolete">Сисоидная форма комплексных чисел</translation>
+        <translation>Биективное основание-26</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1247"/>
         <source>Binary Number</source>
-        <translation type="unfinished">Двоичное число</translation>
+        <translation>Двоичное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1251"/>
         <source>Complex cis Form</source>
-        <translation type="unfinished">Сисоидная форма комплексных чисел</translation>
+        <translation>Сисоидная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1253"/>
         <source>Decimal Number</source>
-        <translation type="unfinished">Десятичное число</translation>
+        <translation>Десятичное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1255"/>
         <source>Duodecimal Number</source>
-        <translation type="unfinished">Двенадцатеричное число</translation>
+        <translation>Двенадцатеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1257"/>
         <source>Complex Exponential Form</source>
-        <translation type="unfinished">Экспоненциальная форма комплексных чисел</translation>
+        <translation>Экспоненциальная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1261"/>
         <source>16-bit Floating Point Binary Format</source>
-        <translation type="unfinished">16-битное в двоичном формате с плавающей запятой</translation>
+        <translation>16-битное в двоичном формате с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1263"/>
         <source>32-bit Floating Point Binary Format</source>
-        <translation type="unfinished">32-битное в двоичном формате с плавающей запятой</translation>
+        <translation>32-битное в двоичном формате с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1265"/>
         <source>64-bit Floating Point Binary Format</source>
-        <translation type="unfinished">64-битное в двоичном формате с плавающей запятой</translation>
+        <translation>64-битное в двоичном формате с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1267"/>
         <source>80-bit (x86) Floating Point Binary Format</source>
-        <translation type="unfinished">80-битное (x86) в двоичном формате с плавающей запятой</translation>
+        <translation>80-битное (x86) в двоичном формате с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1269"/>
         <source>128-bit Floating Point Binary Format</source>
-        <translation type="unfinished">128-битное в двоичном формате с плавающей запятой</translation>
+        <translation>128-битное в двоичном формате с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1273"/>
         <source>Hexadecimal Number</source>
-        <translation type="unfinished">Шестнадцатеричное число</translation>
+        <translation>Шестнадцатеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1279"/>
         <source>Mixed Units</source>
-        <translation type="unfinished">Смешанные единицы измерения</translation>
+        <translation>Смешанные единицы измерения</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1281"/>
         <source>Octal Number</source>
-        <translation type="unfinished">Восьмеричное число</translation>
-    </message>
-    <message>
-        <source>Optimal Units</source>
-        <translation type="obsolete">Оптимальные единицы измерения</translation>
+        <translation>Восьмеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1283"/>
         <source>Optimal Unit</source>
-        <translation type="unfinished">Оптимальная единица измерения</translation>
+        <translation>Оптимальная единица измерения</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1285"/>
         <source>Expanded Partial Fractions</source>
-        <translation type="unfinished">Расширенные дробные числа</translation>
+        <translation>Расширенные частичные дроби</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1287"/>
         <source>Complex Polar Form</source>
-        <translation type="unfinished">Полярная форма комплексных чисел</translation>
+        <translation>Полярная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1289"/>
         <source>Complex Rectangular Form</source>
-        <translation type="unfinished">Прямоугольная форма комплексных чисел</translation>
+        <translation>Прямоугольная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1291"/>
         <source>Roman Numerals</source>
-        <translation type="unfinished">Римские цифры</translation>
+        <translation>Римские цифры</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1293"/>
         <source>Sexagesimal Number</source>
-        <translation type="unfinished">Шестидесятеричное число</translation>
+        <translation>Шестидесятеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1295"/>
         <source>Time Format</source>
-        <translation type="unfinished">Формат времени</translation>
+        <translation>Формат времени</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1299"/>
         <source>UTC Time Zone</source>
-        <translation type="unfinished">Часовой пояс UTC</translation>
+        <translation>Часовой пояс UTC</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1610"/>
         <source>Redo</source>
-        <translation type="unfinished">Повторить</translation>
+        <translation>Повторить</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1614"/>
         <source>Cut</source>
-        <translation type="unfinished">Вырезать</translation>
+        <translation>Вырезать</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1617"/>
         <source>Copy</source>
-        <translation type="unfinished">Копировать</translation>
+        <translation>Копировать</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1620"/>
         <source>Paste</source>
-        <translation type="unfinished">Вставить</translation>
+        <translation>Вставить</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1623"/>
         <source>Delete</source>
-        <translation type="unfinished">Удалить</translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1627"/>
         <source>Insert Date…</source>
-        <translation type="unfinished">Вставить дату…</translation>
+        <translation>Вставить дату…</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1628"/>
         <source>Insert Matrix…</source>
-        <translation type="unfinished">Вставить матрицу…</translation>
+        <translation>Вставить матрицу…</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1630"/>
         <source>Select All</source>
-        <translation type="unfinished">Выделите все</translation>
+        <translation>Выделите всё</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1633"/>
         <source>Clear</source>
-        <translation type="unfinished">Очистить</translation>
+        <translation>Очистить</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1637"/>
         <source>Completion</source>
-        <translation type="unfinished">Завершение</translation>
+        <translation>Завершение</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1649"/>
         <source>No completion</source>
-        <translation type="unfinished">Без завершения</translation>
+        <translation>Без завершения</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1650"/>
         <source>Limited strict completion</source>
-        <translation type="unfinished">Ограниченное строгое завершение</translation>
+        <translation>Ограниченное строгое завершение</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1651"/>
         <source>Strict completion</source>
-        <translation type="unfinished">Строгое завершение</translation>
+        <translation>Строгое завершение</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1652"/>
         <source>Limited full completion</source>
-        <translation type="unfinished">Ограниченное полное завершение</translation>
+        <translation>Ограниченное полное завершение</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1653"/>
         <source>Full completion</source>
-        <translation type="unfinished">Полное завершение</translation>
+        <translation>Полное завершение</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1655"/>
         <source>Delayed completion</source>
-        <translation type="unfinished">Отложенное завершение</translation>
+        <translation>Отложенное завершение</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1690"/>
         <source>Matrix</source>
-        <translation type="unfinished">Матрица</translation>
+        <translation>Матрица</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1832"/>
         <source>Too many arguments for %1().</source>
-        <translation type="unfinished">Слишком много аргументов для %1().</translation>
+        <translation>Слишком много аргументов для %1().</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1857"/>
         <source>argument</source>
-        <translation type="unfinished">аргумент</translation>
+        <translation>аргумент</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1874"/>
         <source>%1:</source>
-        <translation type="unfinished">%1:</translation>
+        <translation>%1:</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1928"/>
         <source>MC (memory clear)</source>
-        <translation type="unfinished">MC (отчистить память)</translation>
+        <translation>MC (отчистить память)</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1931"/>
         <source>MS (memory store)</source>
-        <translation type="unfinished">MS (сохранить в памяти)</translation>
+        <translation>MS (сохранить в памяти)</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1934"/>
         <source>M+ (memory plus)</source>
-        <translation type="unfinished">M+ (прибавить к значению в памяти)</translation>
+        <translation>M+ (прибавить к значению в памяти)</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1937"/>
         <source>M− (memory minus)</source>
-        <translation type="unfinished">M− (отнять от значения в памяти)</translation>
+        <translation>M− (отнять от значения в памяти)</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1945"/>
         <location filename="../src/expressionedit.cpp" line="1947"/>
         <source>factorize</source>
-        <translation type="unfinished">разложить на множители</translation>
+        <translation>разложить на множители</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1948"/>
         <location filename="../src/expressionedit.cpp" line="1950"/>
         <source>expand</source>
-        <translation type="unfinished">раскрывать</translation>
+        <translation>раскрывать</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2097"/>
         <source>hexadecimal</source>
-        <translation type="unfinished">шестнадцатеричное</translation>
+        <translation>шестнадцатеричное</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2098"/>
         <location filename="../src/expressionedit.cpp" line="2208"/>
         <source>hexadecimal number</source>
-        <translation type="unfinished">шестнадцатеричное число</translation>
+        <translation>шестнадцатеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2099"/>
         <source>octal</source>
-        <translation type="unfinished">восьмеричное</translation>
+        <translation>восьмеричное</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2100"/>
         <source>octal number</source>
-        <translation type="unfinished">восьмеричное число</translation>
+        <translation>восьмеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2101"/>
         <source>decimal</source>
-        <translation type="unfinished">десятеричное</translation>
+        <translation>десятеричное</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2102"/>
         <source>decimal number</source>
-        <translation type="unfinished">десятичное число</translation>
+        <translation>десятичное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2103"/>
         <source>duodecimal</source>
-        <translation type="unfinished">двенадцатеричное</translation>
+        <translation>двенадцатеричное</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2104"/>
         <source>duodecimal number</source>
-        <translation type="unfinished">двенадцатеричное число</translation>
+        <translation>двенадцатеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2105"/>
         <source>binary</source>
-        <translation type="unfinished">двоичное</translation>
+        <translation>двоичное</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2106"/>
         <location filename="../src/expressionedit.cpp" line="2202"/>
         <source>binary number</source>
-        <translation type="unfinished">двоичное число</translation>
+        <translation>двоичное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2107"/>
         <source>roman</source>
-        <translation type="unfinished">римское число</translation>
+        <translation>римское число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2108"/>
         <source>roman numerals</source>
-        <translation type="unfinished">римские цифры</translation>
+        <translation>римские цифры</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2109"/>
         <source>bijective</source>
-        <translation type="unfinished">биективное</translation>
+        <translation>биективное</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2110"/>
         <source>bijective base-26</source>
-        <translation type="unfinished">биективное основание-26</translation>
+        <translation>биективное основание-26</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2111"/>
         <source>sexagesimal</source>
-        <translation type="unfinished">шестидесятеричное</translation>
+        <translation>шестидесятеричное</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2112"/>
         <source>sexagesimal number</source>
-        <translation type="unfinished">шестидесятеричное число</translation>
+        <translation>шестидесятеричное число</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2113"/>
         <location filename="../src/expressionedit.cpp" line="2114"/>
         <source>latitude</source>
-        <translation type="unfinished">широта</translation>
+        <translation>широта</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2115"/>
         <location filename="../src/expressionedit.cpp" line="2116"/>
         <source>longitude</source>
-        <translation type="unfinished">долгота</translation>
+        <translation>долгота</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2118"/>
         <source>32-bit floating point</source>
-        <translation type="unfinished">32-битное с плавающей запятой</translation>
+        <translation>32-битное с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2120"/>
         <source>64-bit floating point</source>
-        <translation type="unfinished">64-битное с плавающей запятой</translation>
+        <translation>64-битное с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2122"/>
         <source>16-bit floating point</source>
-        <translation type="unfinished">16-битное с плавающей запятой</translation>
+        <translation>16-битное с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2124"/>
         <source>80-bit (x86) floating point</source>
-        <translation type="unfinished">80-битное (x86) с плавающей запятой</translation>
+        <translation>80-битное (x86) с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2126"/>
         <source>128-bit floating point</source>
-        <translation type="unfinished">128-битное с плавающей запятой</translation>
+        <translation>128-битное с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2127"/>
         <source>time</source>
-        <translation type="unfinished">время</translation>
+        <translation>время</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2128"/>
         <source>time format</source>
-        <translation type="unfinished">формат времени</translation>
+        <translation>формат времени</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2131"/>
         <source>bases</source>
-        <translation type="unfinished">основания</translation>
+        <translation>основания</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2132"/>
         <source>number bases</source>
-        <translation type="unfinished">основания систем счисления</translation>
+        <translation>основания систем счисления</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2133"/>
         <location filename="../src/expressionedit.cpp" line="2134"/>
         <source>calendars</source>
-        <translation type="unfinished">календари</translation>
+        <translation>календари</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2135"/>
         <source>optimal</source>
-        <translation type="unfinished">оптимально</translation>
+        <translation>оптимально</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2136"/>
         <source>optimal unit</source>
-        <translation type="unfinished">оптимальные единицы измерения</translation>
+        <translation>оптимальная единица измерения</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2137"/>
         <location filename="../src/expressionedit.cpp" line="2212"/>
         <source>base</source>
-        <translation type="unfinished">основание</translation>
+        <translation>основание</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2138"/>
         <source>base units</source>
-        <translation type="unfinished">основные единицы измерения</translation>
+        <translation>основные единицы измерения</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2139"/>
         <source>mixed</source>
-        <translation type="unfinished">смешано</translation>
+        <translation>смешано</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2140"/>
         <source>mixed units</source>
-        <translation type="unfinished">смешанные единицы</translation>
+        <translation>смешанные единицы</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2141"/>
         <location filename="../src/expressionedit.cpp" line="2142"/>
         <source>fraction</source>
-        <translation type="unfinished">дробь</translation>
+        <translation>дробь</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2143"/>
         <location filename="../src/expressionedit.cpp" line="2144"/>
         <source>factors</source>
-        <translation type="unfinished">множители</translation>
+        <translation>множители</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2145"/>
         <source>partial fraction</source>
-        <translation type="unfinished">частичная дробь</translation>
+        <translation>частичная дробь</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2146"/>
         <source>expanded partial fractions</source>
-        <translation type="unfinished">расширенные дробные числа</translation>
+        <translation>расширенные дробные числа</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2147"/>
         <source>rectangular</source>
-        <translation type="unfinished">прямоугоная</translation>
+        <translation>прямоугоная</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2147"/>
         <source>cartesian</source>
-        <translation type="unfinished">декартова</translation>
+        <translation>декартова</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2148"/>
         <source>complex rectangular form</source>
-        <translation type="unfinished">прямоугольная форма комплексных чисел</translation>
+        <translation>прямоугольная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2149"/>
         <source>exponential</source>
-        <translation type="unfinished">экспоненциальная</translation>
+        <translation>экспоненциальная</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2150"/>
         <source>complex exponential form</source>
-        <translation type="unfinished">экспоненциальная форма комплексных чисел</translation>
+        <translation>экспоненциальная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2151"/>
         <source>polar</source>
-        <translation type="unfinished">полярная</translation>
+        <translation>полярная</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2152"/>
         <source>complex polar form</source>
-        <translation type="unfinished">полярная форма комплексных чисел</translation>
+        <translation>полярная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2154"/>
         <source>complex cis form</source>
-        <translation type="unfinished">сисоидная форма комплексных чисел</translation>
+        <translation>сисоидная форма комплексных чисел</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2155"/>
         <source>angle</source>
-        <translation type="unfinished">угловая</translation>
+        <translation>угловая</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2156"/>
         <source>complex angle notation</source>
-        <translation type="unfinished">комплексные числа в обозначении угла</translation>
+        <translation>комплексные числа в обозначении угла</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2157"/>
         <source>phasor</source>
-        <translation type="unfinished">фазовая</translation>
+        <translation>фазовая</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2158"/>
         <source>complex phasor notation</source>
-        <translation type="unfinished">Комплексные числа в обозначении вектора</translation>
+        <translation>Комплексные числа в обозначении вектора</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2213"/>
         <source>number base %1</source>
-        <translation type="unfinished">основание системы счисления %1</translation>
+        <translation>основание системы счисления %1</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="2473"/>
         <source>Data object</source>
-        <translation type="unfinished">Объект данных</translation>
+        <translation>Объект данных</translation>
     </message>
     <message>
         <location filename="../src/expressionedit.cpp" line="1657"/>
         <source>Use input method</source>
-        <translation type="unfinished">Использовать метод ввода</translation>
+        <translation>Использовать метод ввода</translation>
     </message>
 </context>
 <context>
@@ -6093,62 +881,62 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="28"/>
         <source>Floating Point Conversion (IEEE 754)</source>
-        <translation type="unfinished">Преобразование чисел с плавающей запятой (IEEE 754)</translation>
+        <translation>Преобразование чисел с плавающей запятой (IEEE 754)</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="31"/>
         <source>Format</source>
-        <translation type="unfinished">Формат</translation>
+        <translation>Формат</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="33"/>
         <source>16-bit (half precision)</source>
-        <translation type="unfinished">128-битное (половинная точность)</translation>
+        <translation>128-битное (половинная точность)</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="34"/>
         <source>32-bit (single precision)</source>
-        <translation type="unfinished">32-битное (одинарная точность)</translation>
+        <translation>32-битное (одинарная точность)</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="35"/>
         <source>64-bit (double precision)</source>
-        <translation type="unfinished">64-битное (двойная точность)</translation>
+        <translation>64-битное (двойная точность)</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="36"/>
         <source>80-bit (x86 extended format)</source>
-        <translation type="unfinished">80-битное (x86 расширенный формат)</translation>
+        <translation>80-битное (x86 расширенный формат)</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="37"/>
         <source>128-bit (quadruple precision)</source>
-        <translation type="unfinished">128 -битное (четырехкратная точность)</translation>
+        <translation>128 -битное (четырехкратная точность)</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="39"/>
         <source>Decimal value</source>
-        <translation type="unfinished">Десятичное значение</translation>
+        <translation>Десятичное значение</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="41"/>
         <source>Binary representation</source>
-        <translation type="unfinished">Двоичное представление</translation>
+        <translation>Двоичное представление</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="56"/>
         <source>Hexadecimal representation</source>
-        <translation type="unfinished">Шестнадцатеричное представление</translation>
+        <translation>Шестнадцатеричное представление</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="58"/>
         <source>Floating point value</source>
-        <translation type="unfinished">Значение числа с плавающей запятой</translation>
+        <translation>Значение числа с плавающей запятой</translation>
     </message>
     <message>
         <location filename="../src/fpconversiondialog.cpp" line="61"/>
         <source>Conversion error</source>
-        <translation type="unfinished">Ошибка преобразования</translation>
+        <translation>Ошибка преобразования</translation>
     </message>
 </context>
 <context>
@@ -6156,51 +944,51 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="80"/>
         <source>Name:</source>
-        <translation type="unfinished">Имя:</translation>
+        <translation>Имя:</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="83"/>
         <source>Expression:</source>
-        <translation type="unfinished">Выражение:</translation>
+        <translation>Выражение:</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="89"/>
         <source>x, y, z</source>
-        <translation type="unfinished">x, y, z</translation>
+        <translation>x, y, z</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="91"/>
         <source>\x, \y, \z, \a, \b, …</source>
-        <translation type="unfinished">\x, \y, \z, \a, \b, …</translation>
+        <translation>\x, \y, \z, \a, \b, …</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="109"/>
         <location filename="../src/functioneditdialog.cpp" line="141"/>
         <source>A function with the same name already exists.
 Do you want to overwrite the function?</source>
-        <translation type="unfinished">Функция с таким именем уже существует.
+        <translation>Функция с таким именем уже существует.
 Хотите перезаписать функцию?</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="213"/>
         <source>Edit Function</source>
-        <translation type="unfinished">Изменить функцию</translation>
+        <translation>Изменить функцию</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="226"/>
         <source>New Function</source>
-        <translation type="unfinished">Новая функция</translation>
+        <translation>Новая функция</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="88"/>
         <source>Argument references:</source>
-        <translation type="unfinished">Ссылки на аргументы:</translation>
+        <translation>Ссылки на аргументы:</translation>
     </message>
     <message>
         <location filename="../src/functioneditdialog.cpp" line="109"/>
         <location filename="../src/functioneditdialog.cpp" line="141"/>
         <source>Question</source>
-        <translation type="unfinished">Вопрос</translation>
+        <translation>Вопрос</translation>
     </message>
 </context>
 <context>
@@ -6208,135 +996,135 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/functionsdialog.cpp" line="34"/>
         <source>Functions</source>
-        <translation type="unfinished">Функции</translation>
+        <translation>Функции</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="43"/>
         <source>Category</source>
-        <translation type="unfinished">Категория</translation>
+        <translation>Категория</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="60"/>
         <location filename="../src/functionsdialog.cpp" line="486"/>
         <source>Function</source>
-        <translation type="unfinished">Функция</translation>
+        <translation>Функция</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="81"/>
         <source>New…</source>
-        <translation type="unfinished">Новый…</translation>
+        <translation>Новая…</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="82"/>
         <source>Edit…</source>
-        <translation type="unfinished">Правка…</translation>
+        <translation>Правка…</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="83"/>
         <location filename="../src/functionsdialog.cpp" line="418"/>
         <location filename="../src/functionsdialog.cpp" line="421"/>
         <source>Deactivate</source>
-        <translation type="unfinished">Деактивировать</translation>
+        <translation>Деактивировать</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="84"/>
         <source>Delete</source>
-        <translation type="unfinished">Удалить</translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="86"/>
         <source>Calculate…</source>
-        <translation type="unfinished">Рассчитать…</translation>
+        <translation>Рассчитать…</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="88"/>
         <source>Apply</source>
-        <translation type="unfinished">Применить</translation>
+        <translation>Применить</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="89"/>
         <source>Insert</source>
-        <translation type="unfinished">Вставить</translation>
+        <translation>Вставить</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="303"/>
         <source>argument</source>
-        <translation type="unfinished">аргумент</translation>
+        <translation>аргумент</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="326"/>
         <source>Retrieves data from the %1 data set for a given object and property. If &quot;info&quot; is typed as property, a dialog window will pop up with all properties of the object.</source>
-        <translation type="unfinished">Извлекает данные из набора данных %1 для заданного объекта и свойства. Если «инфо» введено как свойство, появится диалоговое окно со всеми свойствами объекта.</translation>
+        <translation>Извлекает данные из набора данных %1 для заданного объекта и свойства. Если «инфо» введено как свойство, появится диалоговое окно со всеми свойствами объекта.</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="336"/>
         <source>Example:</source>
-        <translation type="unfinished">Пример:</translation>
+        <translation>Пример:</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="348"/>
         <source>Arguments</source>
-        <translation type="unfinished">Аргументы</translation>
+        <translation>Аргументы</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="365"/>
         <source>optional</source>
         <comment>optional argument</comment>
-        <translation type="unfinished">необязательный</translation>
+        <translation>необязательный</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="368"/>
         <source>default:</source>
         <comment>argument default</comment>
-        <translation type="unfinished">по умолчанию:</translation>
+        <translation>по умолчанию:</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="380"/>
         <source>Requirement:</source>
         <comment>Required condition for function</comment>
-        <translation type="unfinished">Требование:</translation>
+        <translation>Требование:</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="388"/>
         <source>Properties</source>
-        <translation type="unfinished">Свойства</translation>
+        <translation>Свойства</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="395"/>
         <source>%1:</source>
-        <translation type="unfinished">%1:</translation>
+        <translation>%1:</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="405"/>
         <source>key</source>
         <extracomment>indicating that the property is a data set key</extracomment>
-        <translation type="unfinished">ключ</translation>
+        <translation>ключ</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="423"/>
         <source>Activate</source>
-        <translation type="unfinished">Активировать</translation>
+        <translation>Активировать</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="543"/>
         <source>All</source>
         <comment>All functions</comment>
-        <translation type="unfinished">Все</translation>
+        <translation>Все</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="586"/>
         <source>Uncategorized</source>
-        <translation type="unfinished">Без категорий</translation>
+        <translation>Без категорий</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="592"/>
         <source>User functions</source>
-        <translation type="unfinished">Пользовательские функции</translation>
+        <translation>Пользовательские функции</translation>
     </message>
     <message>
         <location filename="../src/functionsdialog.cpp" line="599"/>
         <source>Inactive</source>
-        <translation type="unfinished">Неактивный</translation>
+        <translation>Неактивные</translation>
     </message>
 </context>
 <context>
@@ -6344,22 +1132,22 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/historyview.cpp" line="397"/>
         <source>Copy</source>
-        <translation type="unfinished">Копировать</translation>
+        <translation>Копировать</translation>
     </message>
     <message>
         <location filename="../src/historyview.cpp" line="400"/>
         <source>Copy Formatted Text</source>
-        <translation type="unfinished">Копировать отформатированный текст</translation>
+        <translation>Копировать отформатированный текст</translation>
     </message>
     <message>
         <location filename="../src/historyview.cpp" line="401"/>
         <source>Select All</source>
-        <translation type="unfinished">Выделите все</translation>
+        <translation>Выделите всё</translation>
     </message>
     <message>
         <location filename="../src/historyview.cpp" line="404"/>
         <source>Clear</source>
-        <translation type="unfinished">Очистить</translation>
+        <translation>Очистить</translation>
     </message>
 </context>
 <context>
@@ -6367,17 +1155,17 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/keypadwidget.cpp" line="503"/>
         <source>&lt;i&gt;Right-click/long press&lt;/i&gt;: %1</source>
-        <translation type="unfinished">&lt;i&gt;Щелчок правой кнопкой/долгое нажатие&lt;/i&gt;: %1</translation>
+        <translation>&lt;i&gt;Щелчок правой кнопкой/долгое нажатие&lt;/i&gt;: %1</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="504"/>
         <source>&lt;i&gt;Right-click&lt;/i&gt;: %1</source>
-        <translation type="unfinished">&lt;i&gt;Щелчок правой кнопкой&lt;/i&gt;: %1</translation>
+        <translation>&lt;i&gt;Щелчок правой кнопкой&lt;/i&gt;: %1</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="508"/>
         <source>&lt;i&gt;Middle-click&lt;/i&gt;: %1</source>
-        <translation type="unfinished">&lt;i&gt;Щелчок средней кнопкой&lt;/i&gt;: %1</translation>
+        <translation>&lt;i&gt;Щелчок средней кнопкой&lt;/i&gt;: %1</translation>
     </message>
 </context>
 <context>
@@ -6385,201 +1173,201 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/keypadwidget.cpp" line="158"/>
         <source>Memory store</source>
-        <translation type="unfinished">Сохранить в памяти)</translation>
+        <translation>Сохранить в памяти</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="161"/>
         <source>Memory clear</source>
-        <translation type="unfinished">Отчистить память</translation>
+        <translation>Отчистить память</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="167"/>
         <source>Memory recall</source>
-        <translation type="unfinished">Вызвать из памяти</translation>
+        <translation>Вызвать из памяти</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="173"/>
         <source>Memory add</source>
-        <translation type="unfinished">Прибавить к значению в памяти</translation>
+        <translation>Прибавить к значению в памяти</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="173"/>
         <source>Memory subtract</source>
-        <translation type="unfinished">Отнять от значения в памяти</translation>
+        <translation>Отнять от значения в памяти</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="224"/>
         <source>Uncertainty/interval</source>
-        <translation type="unfinished">Неопределённость/интервал</translation>
+        <translation>Неопределённость/интервал</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="224"/>
         <source>Relative error</source>
-        <translation type="unfinished">Относительная ошибка</translation>
+        <translation>Относительная ошибка</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="224"/>
         <source>Interval</source>
-        <translation type="unfinished">Интервал</translation>
+        <translation>Интервал</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="226"/>
         <source>Move cursor left</source>
-        <translation type="unfinished">Перемещать курсор влево</translation>
+        <translation>Перемещать курсор влево</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="226"/>
         <source>Move cursor to start</source>
-        <translation type="unfinished">Переместить курсор в начало</translation>
+        <translation>Переместить курсор в начало</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="232"/>
         <source>Move cursor right</source>
-        <translation type="unfinished">Перемещать курсор вправо</translation>
+        <translation>Перемещать курсор вправо</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="232"/>
         <source>Move cursor to end</source>
-        <translation type="unfinished">Переместить курсор в конец</translation>
+        <translation>Переместить курсор в конец</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="240"/>
         <source>Left parenthesis</source>
-        <translation type="unfinished">Левая скобка</translation>
+        <translation>Левая скобка</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="240"/>
         <source>Left vector bracket</source>
-        <translation type="unfinished">Левая векторная скобка</translation>
+        <translation>Левая векторная скобка</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="242"/>
         <source>Right parenthesis</source>
-        <translation type="unfinished">Правая скобка</translation>
+        <translation>Правая скобка</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="242"/>
         <source>Right vector bracket</source>
-        <translation type="unfinished">Правая векторная скобка</translation>
+        <translation>Правая векторная скобка</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="244"/>
         <source>Smart parentheses</source>
-        <translation type="unfinished">Умные скобки</translation>
+        <translation>Умные скобки</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="244"/>
         <source>Vector brackets</source>
-        <translation type="unfinished">Векторные скобки</translation>
+        <translation>Векторные скобки</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="250"/>
         <source>Argument separator</source>
-        <translation type="unfinished">Разделитель аргументов</translation>
+        <translation>Разделитель аргументов</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="250"/>
         <location filename="../src/keypadwidget.cpp" line="269"/>
         <source>Blank space</source>
-        <translation type="unfinished">Пустой пробел</translation>
+        <translation>Пустой пробел</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="250"/>
         <location filename="../src/keypadwidget.cpp" line="269"/>
         <source>New line</source>
-        <translation type="unfinished">Новая строка</translation>
+        <translation>Новая строка</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="269"/>
         <source>Decimal point</source>
-        <translation type="unfinished">Десятичная точка</translation>
+        <translation>Десятичная точка</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="297"/>
         <source>Previous result (static)</source>
-        <translation type="unfinished">Предыдущий результат (статический)</translation>
+        <translation>Предыдущий результат (статический)</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="303"/>
         <source>Bitwise AND</source>
-        <translation type="unfinished">Побитовое И</translation>
+        <translation>Побитовое И</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="308"/>
         <source>Delete</source>
-        <translation type="unfinished">Удалить</translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="308"/>
         <source>Backspace</source>
-        <translation type="unfinished">Обратное перемещение</translation>
+        <translation>Обратное перемещение</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="323"/>
         <source>Bitwise OR</source>
-        <translation type="unfinished">Побитовое ИЛИ</translation>
+        <translation>Побитовое ИЛИ</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="323"/>
         <source>Bitwise NOT</source>
-        <translation type="unfinished">Побитовое НЕ</translation>
+        <translation>Побитовое НЕ</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="325"/>
         <source>Clear expression</source>
-        <translation type="unfinished">Отчистить выражение</translation>
+        <translation>Отчистить выражение</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="331"/>
         <source>Calculate expression</source>
-        <translation type="unfinished">Вычислить выражение</translation>
+        <translation>Вычислить выражение</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="192"/>
         <source>Exponentiation</source>
-        <translation type="unfinished">Возведение в степень</translation>
+        <translation>Возведение в степень</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="222"/>
         <source>Percent or remainder</source>
-        <translation type="unfinished">Процент или остаток</translation>
+        <translation>Процент или остаток</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="303"/>
         <source>Multiplication</source>
-        <translation type="unfinished">Умножение</translation>
+        <translation>Умножение</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="303"/>
         <source>Bitwise Shift</source>
-        <translation type="unfinished">Побитовый сдвиг</translation>
+        <translation>Побитовый сдвиг</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="311"/>
         <source>Addition</source>
-        <translation type="unfinished">Сложение</translation>
+        <translation>Сложение</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="311"/>
         <source>Plus</source>
-        <translation type="unfinished">Плюс</translation>
+        <translation>Плюс</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="316"/>
         <location filename="../src/keypadwidget.cpp" line="319"/>
         <source>Subtraction</source>
-        <translation type="unfinished">Вычитание</translation>
+        <translation>Вычитание</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="316"/>
         <location filename="../src/keypadwidget.cpp" line="319"/>
         <source>Minus</source>
-        <translation type="unfinished">Минус</translation>
+        <translation>Минус</translation>
     </message>
     <message>
         <location filename="../src/keypadwidget.cpp" line="323"/>
         <source>Division</source>
-        <translation type="unfinished">Деление</translation>
+        <translation>Деление</translation>
     </message>
 </context>
 <context>
@@ -6587,297 +1375,293 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/plotdialog.cpp" line="45"/>
         <source>Plot</source>
-        <translation type="unfinished">График</translation>
+        <translation>График</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="54"/>
         <source>Data</source>
-        <translation type="unfinished">Данные</translation>
+        <translation>Данные</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="56"/>
         <location filename="../src/plotdialog.cpp" line="147"/>
         <source>Title:</source>
-        <translation type="unfinished">Заголовок:</translation>
+        <translation>Заголовок:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="58"/>
         <source>Expression:</source>
-        <translation type="unfinished">Выражение:</translation>
+        <translation>Выражение:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="63"/>
         <source>Function</source>
-        <translation type="unfinished">Функция</translation>
+        <translation>Функция</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="64"/>
         <source>Vector/matrix</source>
-        <translation type="unfinished">Вектор/матрица</translation>
+        <translation>Вектор/матрица</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="65"/>
         <source>Paired matrix</source>
-        <translation type="unfinished">Парная матрица</translation>
+        <translation>Парная матрица</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="68"/>
         <source>Rows</source>
-        <translation type="unfinished">Строки</translation>
+        <translation>Строки</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="69"/>
         <source>X variable:</source>
-        <translation type="unfinished">Переменная X:</translation>
+        <translation>Переменная X:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="74"/>
         <source>Style:</source>
-        <translation type="unfinished">Стиль:</translation>
+        <translation>Стиль:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="76"/>
         <source>Line</source>
-        <translation type="unfinished">Линия</translation>
+        <translation>Линия</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="77"/>
         <source>Points</source>
-        <translation type="unfinished">Символы</translation>
+        <translation>Символы</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="78"/>
         <source>Line with points</source>
-        <translation type="unfinished">Линия с символами</translation>
+        <translation>Линия с символами</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="79"/>
         <source>Boxes/bars</source>
-        <translation type="unfinished">Прямоугольники/планки погрешностей</translation>
+        <translation>Прямоугольники/планки погрешностей</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="80"/>
         <source>Histogram</source>
-        <translation type="unfinished">Гистограмма</translation>
+        <translation>Гистограмма</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="81"/>
         <source>Steps</source>
-        <translation type="unfinished">Ступенчатый</translation>
+        <translation>Ступенчатый</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="82"/>
         <source>Candlesticks</source>
-        <translation type="unfinished">Японские свечи</translation>
+        <translation>Японские свечи</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="83"/>
         <source>Dots</source>
-        <translation type="unfinished">Точки</translation>
+        <translation>Точки</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="85"/>
         <source>Smoothing:</source>
-        <translation type="unfinished">Сглаживание:</translation>
+        <translation>Сглаживание:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="87"/>
         <location filename="../src/plotdialog.cpp" line="182"/>
         <source>None</source>
-        <translation type="unfinished">Никакой</translation>
+        <translation>Никакой</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="88"/>
         <source>Monotonic</source>
-        <translation type="unfinished">Монотонное</translation>
+        <translation>Монотонное</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="89"/>
         <source>Natural cubic splines</source>
-        <translation type="unfinished">Естественные кубические сплайны</translation>
+        <translation>Естественные кубические сплайны</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="90"/>
         <source>Bezier</source>
-        <translation type="unfinished">Безье</translation>
+        <translation>Безье</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="91"/>
         <source>Bezier (monotonic)</source>
-        <translation type="unfinished">Безье (монотонный)</translation>
+        <translation>Безье (монотонное)</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="93"/>
         <source>Y-axis:</source>
-        <translation type="unfinished">Ось Y:</translation>
+        <translation>Ось Y:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="95"/>
         <source>Primary</source>
-        <translation type="unfinished">Основная</translation>
+        <translation>Основная</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="96"/>
         <source>Secondary</source>
-        <translation type="unfinished">Вторичная</translation>
+        <translation>Вторичная</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="101"/>
         <source>Add</source>
-        <translation type="unfinished">Добавить</translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="104"/>
         <location filename="../src/plotdialog.cpp" line="140"/>
         <location filename="../src/plotdialog.cpp" line="190"/>
         <source>Apply</source>
-        <translation type="unfinished">Применить</translation>
+        <translation>Применить</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="107"/>
         <source>Remove</source>
-        <translation type="unfinished">Удалить</translation>
-    </message>
-    <message>
-        <source>Category</source>
-        <translation type="obsolete">Категория</translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="114"/>
         <source>Title</source>
-        <translation type="unfinished">Заголовок</translation>
+        <translation>Заголовок</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="114"/>
         <source>Expression</source>
-        <translation type="unfinished">Выражение</translation>
+        <translation>Выражение</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="120"/>
         <source>Function Range</source>
-        <translation type="unfinished">Диапазон функция</translation>
+        <translation>Диапазон функции</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="122"/>
         <source>Minimum x value:</source>
-        <translation type="unfinished">Минимальное значение x:</translation>
+        <translation>Минимальное значение x:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="125"/>
         <source>Maximum x value:</source>
-        <translation type="unfinished">Максимальное значение x:</translation>
+        <translation>Максимальное значение x:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="129"/>
         <source>Sampling rate:</source>
-        <translation type="unfinished">Частота дискретизации:</translation>
+        <translation>Частота дискретизации:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="134"/>
         <source>Step size:</source>
-        <translation type="unfinished">Размер шага:</translation>
+        <translation>Размер шага:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="145"/>
         <source>Appearance</source>
-        <translation type="unfinished">Внешний вид</translation>
+        <translation>Внешний вид</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="149"/>
         <source>Display grid</source>
-        <translation type="unfinished">Показать сетку</translation>
+        <translation>Показать сетку</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="151"/>
         <source>Display full border</source>
-        <translation type="unfinished">Показать полную рамку</translation>
+        <translation>Показать полную рамку</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="153"/>
         <source>Minimum y value:</source>
-        <translation type="unfinished">Минимальное значение y:</translation>
+        <translation>Минимальное значение y:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="158"/>
         <source>Maximum y value:</source>
-        <translation type="unfinished">Максимальное значение y:</translation>
+        <translation>Максимальное значение y:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="163"/>
         <source>Logarithmic x scale:</source>
-        <translation type="unfinished">Логарифмическая шкала абсцисс x:</translation>
+        <translation>Логарифмическая шкала абсцисс x:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="168"/>
         <source>Logarithmic y scale:</source>
-        <translation type="unfinished">Логарифмическая шкала ординат y:</translation>
+        <translation>Логарифмическая шкала ординат y:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="173"/>
         <source>X-axis label:</source>
-        <translation type="unfinished">Подпись для оси абсцисс X:</translation>
+        <translation>Подпись для оси абсцисс X:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="175"/>
         <source>Y-axis label:</source>
-        <translation type="unfinished">Подпись для оси ординат Y:</translation>
+        <translation>Подпись для оси ординат Y:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="177"/>
         <source>Line width:</source>
-        <translation type="unfinished">Толщина линии:</translation>
+        <translation>Толщина линии:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="180"/>
         <source>Legend placement:</source>
-        <translation type="unfinished">Размещение легенды:</translation>
+        <translation>Размещение легенды:</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="183"/>
         <source>Top-left</source>
-        <translation type="unfinished">Сверху слева</translation>
+        <translation>Сверху слева</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="184"/>
         <source>Top-right</source>
-        <translation type="unfinished">Сверху справа</translation>
+        <translation>Сверху справа</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="185"/>
         <source>Bottom-left</source>
-        <translation type="unfinished">Снизу слева</translation>
+        <translation>Снизу слева</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="186"/>
         <source>Bottom-right</source>
-        <translation type="unfinished">Снизу справа</translation>
+        <translation>Снизу справа</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="187"/>
         <source>Below</source>
-        <translation type="unfinished">Ниже</translation>
+        <translation>Ниже</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="188"/>
         <source>Outside</source>
-        <translation type="unfinished">Извне</translation>
+        <translation>Извне</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="350"/>
         <location filename="../src/plotdialog.cpp" line="351"/>
         <source>Calculating…</source>
-        <translation type="unfinished">Расчёт…</translation>
+        <translation>Расчёт…</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="350"/>
         <location filename="../src/plotdialog.cpp" line="497"/>
         <source>Cancel</source>
-        <translation type="unfinished">Отмена</translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../src/plotdialog.cpp" line="497"/>
         <source>Processing…</source>
-        <translation type="unfinished">Обработка…</translation>
+        <translation>Обработка…</translation>
     </message>
 </context>
 <context>
@@ -6885,484 +1669,468 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="54"/>
         <source>Look &amp;&amp; Feel</source>
-        <translation type="unfinished">Внешний вид</translation>
+        <translation>Внешний вид</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="55"/>
         <source>Numbers &amp;&amp; Operators</source>
-        <translation type="unfinished">Числа и операторы</translation>
+        <translation>Числа и операторы</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="56"/>
         <source>Units &amp;&amp; Currencies</source>
-        <translation type="unfinished">Единицы измерения и валюты</translation>
+        <translation>Единицы измерения и валюты</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="57"/>
         <source>Parsing &amp;&amp; Calculation</source>
-        <translation type="unfinished">Разбор и вычисление</translation>
+        <translation>Разбор и вычисление</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="61"/>
         <source>Ignore system language (requires restart)</source>
-        <translation type="unfinished">Игнорировать системный язык (требуется перезапуск)</translation>
+        <translation>Игнорировать системный язык (требуется перезапуск)</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="62"/>
         <source>Allow multiple instances</source>
-        <translation type="unfinished">Разрешить несколько экземпляров</translation>
+        <translation>Разрешить несколько экземпляров</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="63"/>
         <source>Clear history on exit</source>
-        <translation type="unfinished">Очищать историю при выходе</translation>
+        <translation>Очищать историю при выходе</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="64"/>
         <source>Keep above other windows</source>
-        <translation type="unfinished">Поддерживать поверх других окон</translation>
+        <translation>Поддерживать поверх других окон</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="65"/>
         <source>Window title:</source>
-        <translation type="unfinished">Заголовок окна:</translation>
+        <translation>Заголовок окна:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="67"/>
         <source>Application name</source>
-        <translation type="unfinished">Имя приложения</translation>
+        <translation>Имя приложения</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="68"/>
         <source>Result</source>
-        <translation type="unfinished">Результат</translation>
+        <translation>Результат</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="69"/>
         <source>Application name + result</source>
-        <translation type="unfinished">Имя приложения + результат</translation>
+        <translation>Имя приложения + результат</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="73"/>
         <source>Style:</source>
-        <translation type="unfinished">Стиль:</translation>
+        <translation>Стиль:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="76"/>
         <source>Default (requires restart)</source>
         <comment>Default style</comment>
-        <translation type="unfinished">По умолчанию (требуется перезапуск)</translation>
+        <translation>По умолчанию (требуется перезапуск)</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="81"/>
         <source>Dark mode</source>
-        <translation type="unfinished">Темный режим</translation>
+        <translation>Тёмный режим</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="82"/>
         <source>Colorize result</source>
-        <translation type="unfinished">Раскрасить результат</translation>
-    </message>
-    <message>
-        <source>Custom result font</source>
-        <translation type="obsolete">Шрифт результатов</translation>
-    </message>
-    <message>
-        <source>Custom expression font</source>
-        <translation type="obsolete">Шрифт выражения</translation>
-    </message>
-    <message>
-        <source>Custom keypad font</source>
-        <translation type="obsolete">Шрифт клавиатуры</translation>
-    </message>
-    <message>
-        <source>Custom application font</source>
-        <translation type="obsolete">Шрифт приложения</translation>
+        <translation>Раскрасить результат</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="83"/>
         <source>Custom result font:</source>
-        <translation type="unfinished">Шрифт результатов:</translation>
+        <translation>Шрифт результатов:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="86"/>
         <source>Custom expression font:</source>
-        <translation type="unfinished">Шрифт выражения:</translation>
+        <translation>Шрифт выражения:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="89"/>
         <source>Custom keypad font:</source>
-        <translation type="unfinished">Шрифт клавиатуры:</translation>
+        <translation>Шрифт клавиатуры:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="92"/>
         <source>Custom application font:</source>
-        <translation type="unfinished">Шрифт приложения:</translation>
+        <translation>Шрифт приложения:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="98"/>
         <source>Display expression status</source>
-        <translation type="unfinished">Показывать статус выражения</translation>
+        <translation>Показывать статус выражения</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="101"/>
         <source>Delay:</source>
-        <translation type="unfinished">Задержка:</translation>
+        <translation>Задержка:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="110"/>
         <source>Expression after calculation:</source>
-        <translation type="unfinished">Выражение после расчёта:</translation>
+        <translation>Выражение после расчёта:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="112"/>
         <source>Keep expression</source>
-        <translation type="unfinished">Сохранить выражение</translation>
+        <translation>Сохранить выражение</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="113"/>
         <source>Clear expression</source>
-        <translation type="unfinished">Отчистить выражение</translation>
+        <translation>Отчистить выражение</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="114"/>
         <source>Replace with result</source>
-        <translation type="unfinished">Заменить на результат</translation>
+        <translation>Заменить на результат</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="115"/>
         <source>Replace with result if shorter</source>
-        <translation type="unfinished">Заменить на результат, если он короче</translation>
+        <translation>Заменить на результат, если он короче</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="119"/>
         <source>Use keyboard keys for RPN</source>
-        <translation type="unfinished">Использовать клавиатуру для ПОЛИЗ</translation>
+        <translation>Использовать клавиатуру для ПОЛИЗ</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="120"/>
         <source>Parsing mode:</source>
-        <translation type="unfinished">Режим анализа:</translation>
+        <translation>Режим анализа:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="122"/>
         <location filename="../src/preferencesdialog.cpp" line="167"/>
         <source>Adaptive</source>
-        <translation type="unfinished">Адаптивный</translation>
+        <translation>Адаптивный</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="123"/>
         <source>Conventional</source>
-        <translation type="unfinished">Общепринятый</translation>
+        <translation>Общепринятый</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="124"/>
         <source>Implicit multiplication first</source>
-        <translation type="unfinished">Неявный первый</translation>
+        <translation>Неявный первый</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="125"/>
         <source>Chain</source>
-        <translation type="unfinished">Цепь</translation>
+        <translation>Цепь</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="126"/>
         <source>RPN</source>
-        <translation type="unfinished">ПОЛИЗ</translation>
+        <translation>ПОЛИЗ</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="130"/>
         <source>Read precision</source>
-        <translation type="unfinished">Точность чтения</translation>
+        <translation>Точность чтения</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="131"/>
         <source>Limit implicit multiplication</source>
-        <translation type="unfinished">Ограничить неявное умножение</translation>
+        <translation>Ограничить неявное умножение</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="132"/>
         <source>Interval calculation:</source>
-        <translation type="unfinished">Расчёт интервала:</translation>
+        <translation>Расчёт интервала:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="134"/>
         <source>Variance formula</source>
-        <translation type="unfinished">Формула дисперсии</translation>
+        <translation>Формула дисперсии</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="135"/>
         <source>Interval arithmetic</source>
-        <translation type="unfinished">Арифметика интервалов</translation>
+        <translation>Арифметика интервалов</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="139"/>
         <source>Factorize result</source>
-        <translation type="unfinished">Разложить результат на множители</translation>
+        <translation>Разложить результат на множители</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="142"/>
         <source>Binary two&apos;s complement representation</source>
-        <translation type="unfinished">Представление двоичных чисел с дополнительным кодом</translation>
+        <translation>Представление двоичных чисел с дополнительным кодом</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="143"/>
         <source>Hexadecimal two&apos;s complement representation</source>
-        <translation type="unfinished">Представление шестнадцатеричных чисел с дополнительным кодом</translation>
+        <translation>Представление шестнадцатеричных чисел с дополнительным кодом</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="144"/>
         <source>Use lower case letters in non-decimal numbers</source>
-        <translation type="unfinished">Использовать строчные буквы в недесятичных числах</translation>
+        <translation>Использовать строчные буквы в недесятичных числах</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="145"/>
         <source>Spell out logical operators</source>
-        <translation type="unfinished">Изложить логично логические операции</translation>
-    </message>
-    <message>
-        <source>Use E-notation instead of 10^x</source>
-        <translation type="obsolete">Использовать E-нотацию вместо 10^x</translation>
+        <translation>Изложить логично логические операции</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="45"/>
         <source>Preferences</source>
-        <translation type="unfinished">Параметры</translation>
+        <translation>Параметры</translation>
+    </message>
+    <message>
+        <location filename="../src/preferencesdialog.cpp" line="105"/>
+        <source>ms</source>
+        <translation>мс</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="146"/>
         <source>Use E-notation instead of 10^n</source>
-        <translation type="unfinished">Использовать E-нотацию вместо 10^n</translation>
+        <translation>Использовать E-нотацию вместо 10^n</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="147"/>
         <source>Use &apos;j&apos; as imaginary unit</source>
-        <translation type="unfinished">Использовать «j» для мнимой единицы</translation>
+        <translation>Использовать «j» для мнимой единицы</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="148"/>
         <source>Use comma as decimal separator</source>
-        <translation type="unfinished">Использовать точку в качестве десятичного разделителя</translation>
+        <translation>Использовать запятую в качестве десятичного разделителя</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="149"/>
         <source>Ignore comma in numbers</source>
-        <translation type="unfinished">Игнорировать запятую в числах</translation>
+        <translation>Игнорировать запятую в числах</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="150"/>
         <source>Ignore dots in numbers</source>
-        <translation type="unfinished">Игнорировать точки в числах</translation>
+        <translation>Игнорировать точки в числах</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="151"/>
         <source>Round halfway numbers to even</source>
-        <translation type="unfinished">Округлять половинные числа до ближайшего чётного целого числа</translation>
+        <translation>Округлять половинные числа до ближайшего чётного целого числа</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="152"/>
         <source>Indicate repeating decimals</source>
-        <translation type="unfinished">Указывать повторяющиеся десятичные дроби</translation>
+        <translation>Указывать повторяющиеся десятичные дроби</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="157"/>
         <source>Digit grouping:</source>
-        <translation type="unfinished">Группировка цифр:</translation>
+        <translation>Группировка цифр:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="159"/>
         <source>None</source>
-        <translation type="unfinished">Никакой</translation>
+        <translation>Никакой</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="160"/>
         <source>Standard</source>
-        <translation type="unfinished">Стандарт</translation>
+        <translation>Стандарт</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="161"/>
         <source>Local</source>
-        <translation type="unfinished">Локаль</translation>
+        <translation>Локаль</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="165"/>
         <source>Interval display:</source>
-        <translation type="unfinished">Отображение интервалов:</translation>
+        <translation>Отображение интервалов:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="168"/>
         <source>Significant digits</source>
-        <translation type="unfinished">Значимые цифры</translation>
+        <translation>Значимые цифры</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="169"/>
         <source>Interval</source>
-        <translation type="unfinished">Интервал</translation>
+        <translation>Интервал</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="170"/>
         <source>Plus/minus</source>
-        <translation type="unfinished">Плюс/минус</translation>
+        <translation>Плюс/минус</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="171"/>
         <source>Midpoint</source>
-        <translation type="unfinished">Середина</translation>
+        <translation>Середина</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="172"/>
         <source>Lower</source>
-        <translation type="unfinished">Ниже</translation>
+        <translation>Ниже</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="173"/>
         <source>Upper</source>
-        <translation type="unfinished">Выше</translation>
+        <translation>Выше</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="178"/>
         <source>Complex number form:</source>
-        <translation type="unfinished">Комплексная форма:</translation>
+        <translation>Комплексная форма:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="180"/>
         <source>Rectangular</source>
-        <translation type="unfinished">Прямоугольная</translation>
+        <translation>Прямоугольная</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="181"/>
         <source>Exponential</source>
-        <translation type="unfinished">Экспоненциальная</translation>
+        <translation>Экспоненциальная</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="182"/>
         <source>Polar</source>
-        <translation type="unfinished">Полярная</translation>
+        <translation>Полярная</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="183"/>
         <source>Angle/phasor</source>
-        <translation type="unfinished">Угла/вектора</translation>
+        <translation>Угловая/векторная</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="191"/>
         <source>Abbreviate names</source>
-        <translation type="unfinished">Сокращённые имена</translation>
+        <translation>Сокращённые имена</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="192"/>
         <source>Use binary prefixes for information units</source>
-        <translation type="unfinished">Использовать двоичные префиксы для информационных единиц</translation>
+        <translation>Использовать двоичные префиксы для информационных единиц</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="193"/>
         <source>Automatic unit conversion:</source>
-        <translation type="unfinished">Автоматическим преобразованием единиц:</translation>
+        <translation>Автоматическое преобразование единиц:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="195"/>
         <source>No conversion</source>
-        <translation type="unfinished">Без преобразование</translation>
+        <translation>Без преобразования</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="196"/>
         <source>Base units</source>
-        <translation type="unfinished">Основные единицы измерения</translation>
+        <translation>Основные единицы измерения</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="197"/>
         <source>Optimal units</source>
-        <translation type="unfinished">Оптимальные единицы измерения</translation>
+        <translation>Оптимальные единицы измерения</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="198"/>
         <source>Optimal SI units</source>
-        <translation type="unfinished">Оптимальные единицы СИ</translation>
+        <translation>Оптимальные единицы СИ</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="202"/>
         <source>Convert to mixed units</source>
-        <translation type="unfinished">Преобразовать в смешанные единицы</translation>
+        <translation>Преобразовать в смешанные единицы</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="203"/>
         <source>Automatic unit prefixes:</source>
-        <translation type="unfinished">Автоматические префиксы единиц:</translation>
+        <translation>Автоматические префиксы единиц:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="205"/>
         <source>Default</source>
-        <translation type="unfinished">По умолчанию</translation>
+        <translation>По умолчанию</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="206"/>
         <source>No prefixes</source>
-        <translation type="unfinished">Без префиксов</translation>
+        <translation>Без префиксов</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="207"/>
         <source>Prefixes for some units</source>
-        <translation type="unfinished">Префиксы для выбранных единиц</translation>
+        <translation>Префиксы для выбранных единиц</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="208"/>
         <source>Prefixes also for currencies</source>
-        <translation type="unfinished">Префиксы также для валют</translation>
+        <translation>Префиксы также для валют</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="209"/>
         <source>Prefixes for all units</source>
-        <translation type="unfinished">Префиксы для всех единиц</translation>
+        <translation>Префиксы для всех единиц</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="217"/>
         <source>Enable all SI-prefixes</source>
-        <translation type="unfinished">Включить все префиксы СИ</translation>
+        <translation>Включить все префиксы СИ</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="218"/>
         <source>Enable denominator prefixes</source>
-        <translation type="unfinished">Включить префиксы знаменателя</translation>
+        <translation>Включить префиксы знаменателя</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="219"/>
         <source>Enable units in physical constants</source>
-        <translation type="unfinished">Включить единицы измерения в физических константах</translation>
+        <translation>Включить единицы измерения в физических константах</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="220"/>
         <source>Temperature calculation:</source>
-        <translation type="unfinished">Режим расчёта температуры:</translation>
+        <translation>Режим расчёта температуры:</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="222"/>
         <source>Absolute</source>
-        <translation type="unfinished">Абсолютный</translation>
+        <translation>Абсолютный</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="223"/>
         <source>Relative</source>
-        <translation type="unfinished">Относительный</translation>
+        <translation>Относительный</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="224"/>
         <source>Hybrid</source>
-        <translation type="unfinished">Гибридный</translation>
+        <translation>Гибридный</translation>
     </message>
     <message>
         <location filename="../src/preferencesdialog.cpp" line="228"/>
         <source>Exchange rates updates:</source>
-        <translation type="unfinished">Обновления курсов валют:</translation>
+        <translation>Обновления курсов валют:</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/preferencesdialog.cpp" line="229"/>
         <source>days</source>
-        <translation type="unfinished">дни</translation>
-    </message>
-    <message>
-        <location filename="../src/preferencesdialog.cpp" line="105"/>
-        <source> ms</source>
-        <translation type="unfinished"> мс</translation>
+        <translation>
+            <numerusform>день</numerusform>
+            <numerusform>дня</numerusform>
+            <numerusform>дней</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -7370,32 +2138,32 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/main.cpp" line="71"/>
         <source>Execute expressions and commands from a file</source>
-        <translation type="unfinished">Выполнить выражения и команды из файла</translation>
+        <translation>Выполнить выражения и команды из файла</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
         <source>FILE</source>
-        <translation type="unfinished">ФАЙЛ</translation>
+        <translation>ФАЙЛ</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="73"/>
         <source>Start a new instance of the application</source>
-        <translation type="unfinished">Запустить новый экземпляр приложения</translation>
+        <translation>Запустить новый экземпляр приложения</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="75"/>
         <source>Specify the window title</source>
-        <translation type="unfinished">Укажите заголовок окна</translation>
+        <translation>Укажите заголовок окна</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="75"/>
         <source>TITLE</source>
-        <translation type="unfinished">НАЗВАНИЕ</translation>
+        <translation>НАЗВАНИЕ</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="77"/>
         <source>Display the application version</source>
-        <translation type="unfinished">Показать версию приложения</translation>
+        <translation>Показать версию приложения</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="79"/>
@@ -7405,7 +2173,7 @@ Do you want to overwrite the function?</source>
     <message>
         <location filename="../src/main.cpp" line="79"/>
         <source>[EXPRESSION]</source>
-        <translation type="unfinished">[ВЫРАЖЕНИЕ]</translation>
+        <translation>[ВЫРАЖЕНИЕ]</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="95"/>
@@ -7414,7 +2182,7 @@ Do you want to overwrite the function?</source>
 If multiple instances are opened simultaneously, only the definitions (variables, functions, etc.), mode, preferences, and history of the last closed window will be saved.
 
 Do you, despite this, want to change the default behavior and allow multiple simultaneous instances?</source>
-        <translation type="unfinished">По умолчанию разрешён только один экземпляр (одно главное окно) %1.
+        <translation>По умолчанию разрешён только один экземпляр (одно главное окно) %1.
 
 Если несколько экземпляров открыты одновременно, будут сохранены только определения (переменные, функции и т. д.), режим, настройки и история последнего закрытого окна.
 
@@ -7442,17 +2210,17 @@ Do you, despite this, want to change the default behavior and allow multiple sim
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="63"/>
         <source>History Answer Value</source>
-        <translation type="unfinished">Значение ответа в истории</translation>
+        <translation>Значение ответа в истории</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="65"/>
         <source>History Index(es)</source>
-        <translation type="unfinished">Индекс(ы) истории</translation>
+        <translation>Индекс(ы) истории</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="76"/>
         <source>History index %s does not exist.</source>
-        <translation type="unfinished">Индекс истории %s не существует.</translation>
+        <translation>Индекс истории %s не существует.</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="666"/>
@@ -7488,13 +2256,13 @@ Do you, despite this, want to change the default behavior and allow multiple sim
         <location filename="../src/qalculateqtsettings.cpp" line="757"/>
         <source>Couldn&apos;t write preferences to
 %1</source>
-        <translation type="unfinished">Не удалось записать настройки в
+        <translation>Не удалось записать настройки в
 %1</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="757"/>
         <source>Error</source>
-        <translation type="unfinished">Ошибка</translation>
+        <translation>Ошибка</translation>
     </message>
 </context>
 <context>
@@ -7502,14 +2270,14 @@ Do you, despite this, want to change the default behavior and allow multiple sim
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1017"/>
         <source>Update exchange rates?</source>
-        <translation type="unfinished">Обновить курсы валют?</translation>
+        <translation>Обновить курсы валют?</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/qalculateqtsettings.cpp" line="1017"/>
         <source>It has been %n day(s) since the exchange rates last were updated.
 
 Do you wish to update the exchange rates now?</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform>Прошёл %n день с момента последнего обновления курсов обмена.
 
 Вы хотите обновить курсы обмена сейчас?</numerusform>
@@ -7522,48 +2290,44 @@ Do you wish to update the exchange rates now?</source>
         </translation>
     </message>
     <message>
-        <source>Fetching exchange rates.</source>
-        <translation type="obsolete">Получение курсов валют.</translation>
-    </message>
-    <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1045"/>
         <location filename="../src/qalculateqtsettings.cpp" line="1046"/>
         <source>Fetching exchange rates…</source>
-        <translation type="unfinished">Получение курсов валют…</translation>
+        <translation>Получение курсов валют…</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1090"/>
         <source>Path of executable not found.</source>
-        <translation type="unfinished">Путь к исполняемому файлу не найден.</translation>
+        <translation>Путь к исполняемому файлу не найден.</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1099"/>
         <source>curl not found.</source>
-        <translation type="unfinished">Программа curl не найдена.</translation>
+        <translation>Программа curl не найдена.</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1150"/>
         <source>Failed to run update script.
 %1</source>
-        <translation type="unfinished">Не удалось запустить скрипт обновления.
+        <translation>Не удалось запустить скрипт обновления.
 %1</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1173"/>
         <source>Failed to check for updates.</source>
-        <translation type="unfinished">Не удалось проверить наличие обновлений.</translation>
+        <translation>Не удалось проверить наличие обновлений.</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1174"/>
         <source>No updates found.</source>
-        <translation type="unfinished">Обновлений не найдено.</translation>
+        <translation>Обновлений не найдено.</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1180"/>
         <source>A new version of %1 is available at %2.
 
 Do you wish to update to version %3?</source>
-        <translation type="unfinished">Новая версия %1 доступна на %2.
+        <translation>Новая версия %1 доступна: %2.
 
 Вы хотите обновиться до версии %3?</translation>
     </message>
@@ -7572,9 +2336,9 @@ Do you wish to update to version %3?</source>
         <source>A new version of %1 is available.
 
 You can get version %3 at %2.</source>
-        <translation type="unfinished">Доступна новая версия %1.
+        <translation>Доступна новая версия %1.
 
-Вы можете получить версию %3 на %2.</translation>
+Вы можете получить версию %3: %2.</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1077"/>
@@ -7583,17 +2347,17 @@ You can get version %3 at %2.</source>
         <location filename="../src/qalculateqtsettings.cpp" line="1150"/>
         <location filename="../src/qalculateqtsettings.cpp" line="1173"/>
         <source>Error</source>
-        <translation type="unfinished">Ошибка</translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1078"/>
         <source>Warning</source>
-        <translation type="unfinished">Предупреждение</translation>
+        <translation>Предупреждение</translation>
     </message>
     <message>
         <location filename="../src/qalculateqtsettings.cpp" line="1079"/>
         <source>Information</source>
-        <translation type="unfinished">Информирование</translation>
+        <translation>Информирование</translation>
     </message>
 </context>
 <context>
@@ -7602,67 +2366,67 @@ You can get version %3 at %2.</source>
         <location filename="../src/main.cpp" line="199"/>
         <source>Cancel</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">Отмена</translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="201"/>
         <source>Close</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">Выход</translation>
+        <translation>Закрыть</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="197"/>
         <source>OK</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">ОК</translation>
+        <translation>ОК</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="203"/>
         <source>&amp;Yes</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">&amp;Да</translation>
+        <translation>&amp;Да</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="205"/>
         <source>&amp;No</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">&amp;Нет</translation>
+        <translation>&amp;Нет</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="207"/>
         <source>&amp;Open</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">&amp;Открыть</translation>
+        <translation>&amp;Открыть</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="209"/>
         <source>&amp;Save</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">&amp;Сохранить</translation>
+        <translation>&amp;Сохранить</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="211"/>
         <source>&amp;Select All</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">&amp;Выбрать все</translation>
+        <translation>&amp;Выбрать все</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="213"/>
         <source>Look in:</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">Смотреть в:</translation>
+        <translation>Смотреть в:</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="215"/>
         <source>File &amp;name:</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">Имя &amp;файла</translation>
+        <translation>Имя &amp;файла:</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="217"/>
         <source>Files of type:</source>
         <extracomment>Only used when Qt translation is missing</extracomment>
-        <translation type="unfinished">Тип файлов:</translation>
+        <translation>Тип файлов:</translation>
     </message>
 </context>
 <context>
@@ -7670,515 +2434,515 @@ You can get version %3 at %2.</source>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="291"/>
         <source>Menu</source>
-        <translation type="unfinished">Меню</translation>
+        <translation>Меню</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="292"/>
         <source>Menu (%1)</source>
-        <translation type="unfinished">Меню (%1)</translation>
+        <translation>Меню (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="297"/>
         <source>New</source>
-        <translation type="unfinished">Новая</translation>
+        <translation>Новая</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="298"/>
         <source>Function…</source>
-        <translation type="unfinished">Функция…</translation>
+        <translation>Функция…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="299"/>
         <source>Variable/Constant…</source>
-        <translation type="unfinished">Переменная/константа…</translation>
+        <translation>Переменная/константа…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="300"/>
         <source>Unknown Variable…</source>
-        <translation type="unfinished">Переменная неизвестного…</translation>
+        <translation>Переменная неизвестного…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="301"/>
         <source>Matrix…</source>
-        <translation type="unfinished">Матрица…</translation>
+        <translation>Матрица…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="304"/>
         <source>Import CSV File…</source>
-        <translation type="unfinished">Загрузить CSV файл…</translation>
+        <translation>Загрузить CSV файл…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="305"/>
         <source>Export CSV File…</source>
-        <translation type="unfinished">Экспорт в CSV файл…</translation>
+        <translation>Экспорт в CSV файл…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="307"/>
         <location filename="../src/qalculatewindow.cpp" line="551"/>
         <source>Functions</source>
-        <translation type="unfinished">Функции</translation>
+        <translation>Функции</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="308"/>
         <source>Variables and Constants</source>
-        <translation type="unfinished">Переменные и константы</translation>
+        <translation>Переменные и константы</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="309"/>
         <source>Units</source>
-        <translation type="unfinished">Единицы измерения</translation>
+        <translation>Единицы измерения</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="311"/>
         <source>Plot Functions/Data</source>
-        <translation type="unfinished">Графики функций/данных</translation>
+        <translation>Графики функций/данных</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="312"/>
         <source>Floating Point Conversion (IEEE 754)</source>
-        <translation type="unfinished">Преобразование чисел с плавающей запятой (IEEE 754)</translation>
+        <translation>Преобразование чисел с плавающей запятой (IEEE 754)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="313"/>
         <source>Calendar Conversion</source>
-        <translation type="unfinished">Преобразование календаря</translation>
+        <translation>Преобразование календаря</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="315"/>
         <source>Update Exchange Rates</source>
-        <translation type="unfinished">Обновить курсы валют</translation>
+        <translation>Обновить курсы валют</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="318"/>
         <source>Normal Mode</source>
-        <translation type="unfinished">Режим нормальный</translation>
+        <translation>Режим нормальный</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="319"/>
         <source>RPN Mode</source>
-        <translation type="unfinished">Режим ПОЛИЗ</translation>
+        <translation>Режим ПОЛИЗ</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="320"/>
         <source>Chain Mode</source>
-        <translation type="unfinished">Режим «цепь»</translation>
+        <translation>Режим «цепь»</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="322"/>
         <source>Preferences</source>
-        <translation type="unfinished">Параметры</translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="324"/>
         <source>Help</source>
-        <translation type="unfinished">Справка</translation>
+        <translation>Справка</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="325"/>
         <source>Report a Bug</source>
-        <translation type="unfinished">Сообщить об ошибке</translation>
+        <translation>Сообщить об ошибке</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="326"/>
         <source>Check for Updates</source>
-        <translation type="unfinished">Проверить обновления</translation>
+        <translation>Проверить обновления</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="327"/>
         <location filename="../src/qalculatewindow.cpp" line="328"/>
         <location filename="../src/qalculatewindow.cpp" line="889"/>
         <source>About %1</source>
-        <translation type="unfinished">О %1</translation>
+        <translation>О %1</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="330"/>
         <source>Quit</source>
-        <translation type="unfinished">Выход</translation>
+        <translation>Выход</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="333"/>
         <source>Mode</source>
-        <translation type="unfinished">Режим</translation>
+        <translation>Режим</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="334"/>
         <source>Mode (%1)</source>
-        <translation type="unfinished">Режим (%1)</translation>
+        <translation>Режим (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="339"/>
         <location filename="../src/qalculatewindow.cpp" line="342"/>
         <source>General Display Mode</source>
-        <translation type="unfinished">Режим общего отображения</translation>
+        <translation>Режим общего отображения</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="344"/>
         <source>Normal</source>
-        <translation type="unfinished">Обычное</translation>
+        <translation>Обычное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="347"/>
         <source>Scientific</source>
-        <translation type="unfinished">Научное</translation>
+        <translation>Научное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="350"/>
         <source>Engineering</source>
-        <translation type="unfinished">Инженерное</translation>
+        <translation>Инженерное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="353"/>
         <source>Simple</source>
-        <translation type="unfinished">Простое</translation>
+        <translation>Простое</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="357"/>
         <location filename="../src/qalculatewindow.cpp" line="358"/>
         <source>Angle Unit</source>
-        <translation type="unfinished">Единица измерения углов</translation>
+        <translation>Единица измерения углов</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="360"/>
         <source>Radians</source>
-        <translation type="unfinished">Радианы</translation>
+        <translation>Радианы</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="362"/>
         <source>Degrees</source>
-        <translation type="unfinished">Градусы</translation>
+        <translation>Градусы</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="364"/>
         <source>Gradians</source>
-        <translation type="unfinished">Грады</translation>
+        <translation>Грады</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="367"/>
         <location filename="../src/qalculatewindow.cpp" line="368"/>
         <source>Approximation</source>
-        <translation type="unfinished">Приближение</translation>
+        <translation>Приближение</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="370"/>
         <source>Automatic</source>
         <comment>Automatic approximation</comment>
-        <translation type="unfinished">Автоматическое</translation>
+        <translation>Автоматическое</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="372"/>
         <source>Dual</source>
         <comment>Dual approximation</comment>
-        <translation type="unfinished">Двойное</translation>
+        <translation>Двойное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="374"/>
         <source>Exact</source>
         <comment>Exact approximation</comment>
-        <translation type="unfinished">Точное</translation>
+        <translation>Точное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="376"/>
         <source>Approximate</source>
-        <translation type="unfinished">Приблизительное</translation>
+        <translation>Приблизительное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="381"/>
         <source>Assumptions</source>
-        <translation type="unfinished">Предположения</translation>
+        <translation>Предположения</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="382"/>
         <source>Type</source>
         <comment>Assumptions type</comment>
-        <translation type="unfinished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="384"/>
         <source>Number</source>
-        <translation type="unfinished">Число</translation>
+        <translation>Число</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="386"/>
         <source>Real</source>
-        <translation type="unfinished">Вещественное</translation>
+        <translation>Вещественное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="388"/>
         <source>Rational</source>
-        <translation type="unfinished">Рациональное</translation>
+        <translation>Рациональное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="390"/>
         <source>Integer</source>
-        <translation type="unfinished">Целое</translation>
+        <translation>Целое</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="392"/>
         <source>Boolean</source>
-        <translation type="unfinished">Логическое</translation>
+        <translation>Логическое</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="394"/>
         <source>Sign</source>
         <comment>Assumptions sign</comment>
-        <translation type="unfinished">Знак</translation>
+        <translation>Знак</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="396"/>
         <source>Unknown</source>
         <comment>Unknown assumptions sign</comment>
-        <translation type="unfinished">Неизвестное</translation>
+        <translation>Неизвестное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="398"/>
         <source>Non-zero</source>
-        <translation type="unfinished">Ненулевое</translation>
+        <translation>Ненулевое</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="400"/>
         <source>Positive</source>
-        <translation type="unfinished">Положительное</translation>
+        <translation>Положительное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="402"/>
         <source>Non-negative</source>
-        <translation type="unfinished">Неотрицательное</translation>
+        <translation>Неотрицательное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="404"/>
         <source>Negative</source>
-        <translation type="unfinished">Отрицательное</translation>
+        <translation>Отрицательное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="406"/>
         <source>Non-positive</source>
-        <translation type="unfinished">Не положительное</translation>
+        <translation>Не положительное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="410"/>
         <location filename="../src/qalculatewindow.cpp" line="411"/>
         <source>Result Base</source>
-        <translation type="unfinished">Основание для результата</translation>
+        <translation>Основание для результата</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="414"/>
         <location filename="../src/qalculatewindow.cpp" line="469"/>
         <source>Binary</source>
-        <translation type="unfinished">Двоичное</translation>
+        <translation>Двоичное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="416"/>
         <location filename="../src/qalculatewindow.cpp" line="471"/>
         <source>Octal</source>
-        <translation type="unfinished">Восьмеричное</translation>
+        <translation>Восьмеричное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="418"/>
         <location filename="../src/qalculatewindow.cpp" line="473"/>
         <source>Decimal</source>
-        <translation type="unfinished">Десятичное</translation>
+        <translation>Десятичное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="420"/>
         <location filename="../src/qalculatewindow.cpp" line="475"/>
         <source>Hexadecimal</source>
-        <translation type="unfinished">Шестнадцатеричное</translation>
+        <translation>Шестнадцатеричное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="423"/>
         <location filename="../src/qalculatewindow.cpp" line="478"/>
         <source>Other</source>
-        <translation type="unfinished">Другое</translation>
+        <translation>Другое</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="424"/>
         <location filename="../src/qalculatewindow.cpp" line="479"/>
         <source>Duodecimal</source>
-        <translation type="unfinished">Двенадцатеричное</translation>
+        <translation>Двенадцатеричное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="426"/>
         <source>Sexagesimal</source>
-        <translation type="unfinished">Шестидесятеричное</translation>
+        <translation>Шестидесятеричное</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="428"/>
         <source>Time format</source>
-        <translation type="unfinished">Формат времени</translation>
+        <translation>Формат времени</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="430"/>
         <location filename="../src/qalculatewindow.cpp" line="481"/>
         <source>Roman numerals</source>
-        <translation type="unfinished">Римские цифры</translation>
+        <translation>Римские цифры</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="432"/>
         <location filename="../src/qalculatewindow.cpp" line="483"/>
         <source>Unicode</source>
-        <translation type="unfinished">Юникод</translation>
+        <translation>Юникод</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="434"/>
         <location filename="../src/qalculatewindow.cpp" line="485"/>
         <source>Bijective base-26</source>
-        <translation type="unfinished">Биективное основание-26</translation>
+        <translation>Биективное основание-26</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="497"/>
         <source>Custom:</source>
         <comment>Number base</comment>
-        <translation type="unfinished">Пользовательский:</translation>
+        <translation>Пользовательское:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="465"/>
         <location filename="../src/qalculatewindow.cpp" line="466"/>
         <source>Expression Base</source>
-        <translation type="unfinished">Основание для выражения</translation>
+        <translation>Основание для выражения</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="450"/>
         <source>Other:</source>
         <comment>Number base</comment>
-        <translation type="unfinished">Другое:</translation>
+        <translation>Другое:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="517"/>
         <source>Precision:</source>
-        <translation type="unfinished">Точность:</translation>
+        <translation>Точность:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="524"/>
         <source>Min decimals:</source>
-        <translation type="unfinished">Мин цифр:</translation>
+        <translation>Минимум цифр:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="531"/>
         <source>Max decimals:</source>
-        <translation type="unfinished">Макс цифр:</translation>
+        <translation>Максимум цифр:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="534"/>
         <source>off</source>
         <comment>Max decimals</comment>
-        <translation>выкл.</translation>
+        <translation>выкл</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="544"/>
         <source>Convert</source>
-        <translation type="unfinished">Перевести</translation>
+        <translation>Перевести</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="545"/>
         <source>Convert (%1)</source>
-        <translation type="unfinished">Перевести (%1)</translation>
+        <translation>Перевести (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="548"/>
         <source>Store</source>
-        <translation type="unfinished">Сохранить</translation>
+        <translation>Сохранить</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="548"/>
         <source>Store (%1)</source>
-        <translation type="unfinished">Сохранить (%1)</translation>
+        <translation>Сохранить (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="551"/>
         <source>Functions (%1)</source>
-        <translation type="unfinished">Функции (%1)</translation>
+        <translation>Функции (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="554"/>
         <location filename="../src/qalculatewindow.cpp" line="635"/>
         <source>Keypad</source>
-        <translation type="unfinished">Клавиатура</translation>
+        <translation>Клавиатура</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="555"/>
         <source>Keypad (%1)</source>
-        <translation type="unfinished">Клавиатура (%1)</translation>
+        <translation>Клавиатура (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="559"/>
         <location filename="../src/qalculatewindow.cpp" line="585"/>
         <source>Number bases</source>
-        <translation type="unfinished">Основания систем счисления</translation>
+        <translation>Основания систем счисления</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="560"/>
         <source>Number Bases (%1)</source>
-        <translation type="unfinished">Основания систем счисления (%1)</translation>
+        <translation>Основания систем счисления (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="589"/>
         <source>Binary:</source>
-        <translation type="unfinished">Двоичное:</translation>
+        <translation>Двоичное:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="591"/>
         <source>Octal:</source>
-        <translation type="unfinished">Восьмеричное:</translation>
+        <translation>Восьмеричное:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="593"/>
         <source>Decimal:</source>
-        <translation type="unfinished">Десятичное:</translation>
+        <translation>Десятичное:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="595"/>
         <source>Hexadecimal:</source>
-        <translation type="unfinished">Шестнадцатеричное:</translation>
+        <translation>Шестнадцатеричное:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="642"/>
         <source>RPN Stack</source>
-        <translation type="unfinished">Стек ПОЛИЗ</translation>
+        <translation>Стек ПОЛИЗ</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="661"/>
         <source>Rotate the stack or move the selected register up (%1)</source>
-        <translation type="unfinished">Повернуть стек или переместить выбранный регистр вверх (%1)</translation>
+        <translation>Повернуть стек или переместить выбранный регистр вверх (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="664"/>
         <source>Rotate the stack or move the selected register down (%1)</source>
-        <translation type="unfinished">Повернуть стек или переместить выбранный регистр вниз (%1)</translation>
+        <translation>Повернуть стек или переместить выбранный регистр вниз (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="667"/>
         <source>Swap the top two values or move the selected value to the top of the stack (%1)</source>
-        <translation type="unfinished">Поменять местами два верхних значения или переместить выбранное значение в вершину стека. (%1)</translation>
+        <translation>Поменять местами два верхних значения или переместить выбранное значение в вершину стека (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="670"/>
         <source>Copy the selected or top value to the top of the stack (%1)</source>
-        <translation type="unfinished">Скопировать выбранное или верхнее значение в вершину стека (%1)</translation>
+        <translation>Скопировать выбранное или верхнее значение в вершину стека (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="673"/>
         <source>Enter the top value from before the last numeric operation (%1)</source>
-        <translation type="unfinished">Введите верхнее значение перед последней числовой операцией (%1)</translation>
+        <translation>Введите верхнее значение перед последней числовой операцией (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="676"/>
         <source>Delete the top or selected value (%1)</source>
-        <translation type="unfinished">Удалить верхнее или выбранное значение (%1)</translation>
+        <translation>Удалить верхнее или выбранное значение (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="679"/>
         <source>Clear the RPN stack (%1)</source>
-        <translation type="unfinished">Очистить стек ПОЛИЗ (%1)</translation>
+        <translation>Очистить стек ПОЛИЗ (%1)</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="889"/>
         <source>Powerful and easy to use calculator</source>
-        <translation type="unfinished">Мощный и простой в использовании калькулятор</translation>
+        <translation>Мощный и простой в использовании калькулятор</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="2203"/>
         <source>Couldn&apos;t write definitions</source>
-        <translation type="unfinished">Не удалось записать определения</translation>
+        <translation>Не удалось записать определения</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="2707"/>
@@ -8298,7 +3062,7 @@ You can get version %3 at %2.</source>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="2935"/>
         <source>mixed</source>
-        <translation type="unfinished">смешано</translation>
+        <translation>смешано</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="2949"/>
@@ -8331,14 +3095,14 @@ You can get version %3 at %2.</source>
         <location filename="../src/qalculatewindow.cpp" line="3187"/>
         <location filename="../src/qalculatewindow.cpp" line="3563"/>
         <source>Calculating…</source>
-        <translation type="unfinished">Расчёт…</translation>
+        <translation>Расчёт…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="3186"/>
         <location filename="../src/qalculatewindow.cpp" line="3572"/>
         <location filename="../src/qalculatewindow.cpp" line="4069"/>
         <source>Cancel</source>
-        <translation type="unfinished">Отмена</translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="3239"/>
@@ -8349,22 +3113,22 @@ You can get version %3 at %2.</source>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="3551"/>
         <source>Factorizing…</source>
-        <translation type="unfinished">Факторизация…</translation>
+        <translation>Факторизация…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="3555"/>
         <source>Expanding partial fractions…</source>
-        <translation type="unfinished">Расширение дробных чисел…</translation>
+        <translation>Расширение дробных чисел…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="3559"/>
         <source>Expanding…</source>
-        <translation type="unfinished">Расширение…</translation>
+        <translation>Расширение…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="3567"/>
         <source>Converting…</source>
-        <translation type="unfinished">Преобразование…</translation>
+        <translation>Преобразование…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="3928"/>
@@ -8376,165 +3140,165 @@ You can get version %3 at %2.</source>
         <location filename="../src/qalculatewindow.cpp" line="4069"/>
         <location filename="../src/qalculatewindow.cpp" line="4070"/>
         <source>Processing…</source>
-        <translation type="unfinished">Обработка…</translation>
+        <translation>Обработка…</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4166"/>
         <location filename="../src/qalculatewindow.cpp" line="5380"/>
         <source>Matrix</source>
-        <translation type="unfinished">Матрица</translation>
+        <translation>Матрица</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4267"/>
         <source>Temperature Calculation Mode</source>
-        <translation type="unfinished">Режим расчёта температуры</translation>
+        <translation>Режим расчёта температуры</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4273"/>
         <source>The expression is ambiguous.
 Please select temperature calculation mode
 (the mode can later be changed in preferences).</source>
-        <translation type="unfinished">Выражение неоднозначное.
+        <translation>Выражение неоднозначное.
 Выберите режим расчёта температуры
 (режим позже можно изменить в настройках).</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4276"/>
         <source>Absolute</source>
-        <translation type="unfinished">Абсолютный</translation>
+        <translation>Абсолютный</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4280"/>
         <source>Relative</source>
-        <translation type="unfinished">Относительный</translation>
+        <translation>Относительный</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4284"/>
         <source>Hybrid</source>
-        <translation type="unfinished">Гибридный</translation>
+        <translation>Гибридный</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4324"/>
         <source>Interpretation of dots</source>
-        <translation type="unfinished">Использование точки</translation>
+        <translation>Использование точки</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4330"/>
         <source>Please select interpretation of dots (&quot;.&quot;)
 (this can later be changed in preferences).</source>
-        <translation type="unfinished">Выберите использование точки («.»)
+        <translation>Выберите использование точки («.»)
 (позже это можно изменить в настройках).</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4333"/>
         <source>Both dot and comma as decimal separators</source>
-        <translation type="unfinished">Точка и запятая в качестве десятичных разделителей</translation>
+        <translation>Точка и запятая в качестве десятичных разделителей</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4337"/>
         <source>Dot as thousands separator</source>
-        <translation type="unfinished">Точка как разделитель тысяч</translation>
+        <translation>Точка как разделитель тысяч</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4341"/>
         <source>Only dot as decimal separator</source>
-        <translation type="unfinished">Только точка в качестве десятичного разделителя</translation>
+        <translation>Только точка в качестве десятичного разделителя</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4852"/>
         <source>Gnuplot was not found</source>
-        <translation type="unfinished">Программа Gnuplot не найдена</translation>
+        <translation>Программа Gnuplot не найдена</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="4852"/>
         <source>%1 (%2) needs to be installed separately, and found in the executable search path, for plotting to work.</source>
-        <translation type="unfinished">%1 (%2) должен быть установлен отдельно и находиться по переменной окружения PATH, чтобы график работал.</translation>
+        <translation>Для построения графиков %1 (%2) должен быть установлен дополнительно и находиться по переменной окружения PATH.</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5034"/>
         <source>Example:</source>
         <comment>Example of function usage</comment>
-        <translation type="unfinished">Пример:</translation>
+        <translation>Пример:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5072"/>
         <source>Enter</source>
         <comment>RPN Enter</comment>
-        <translation type="unfinished">Ввод</translation>
+        <translation>Ввод</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5072"/>
         <source>Calculate</source>
-        <translation type="unfinished">Рассчитать</translation>
+        <translation>Рассчитать</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5073"/>
         <source>Apply to Stack</source>
-        <translation type="unfinished">Применить к стеку</translation>
+        <translation>Применить к стеку</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5073"/>
         <source>Insert</source>
-        <translation type="unfinished">Вставить</translation>
+        <translation>Вставить</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5064"/>
         <source>Keep open</source>
-        <translation type="unfinished">Держать открытым</translation>
+        <translation>Держать открытым</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5089"/>
         <source>Value</source>
-        <translation type="unfinished">Значение</translation>
+        <translation>Значение</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5091"/>
         <source>Argument</source>
-        <translation type="unfinished">Аргумент</translation>
+        <translation>Аргумент</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5104"/>
         <source>%1:</source>
-        <translation type="unfinished">%1:</translation>
+        <translation>%1:</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5159"/>
         <source>True</source>
-        <translation type="unfinished">Истина</translation>
+        <translation>Истина</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5162"/>
         <source>False</source>
-        <translation type="unfinished">Ложь</translation>
+        <translation>Ложь</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5188"/>
         <source>Info</source>
-        <translation type="unfinished">Инфо</translation>
+        <translation>Инфо</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5223"/>
         <location filename="../src/qalculatewindow.cpp" line="5231"/>
         <source>optional</source>
         <comment>optional argument</comment>
-        <translation type="unfinished">необязательный</translation>
+        <translation>необязательный</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="5571"/>
         <source>Failed to open %1.
 %2</source>
-        <translation type="unfinished">Не удалось открыть %1.
+        <translation>Не удалось открыть %1.
 %2</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="889"/>
         <source>License: GNU General Public License version 2 or later</source>
-        <translation type="unfinished">Лицензия: GNU General Public License, версия 2 или новее</translation>
+        <translation>Лицензия: GNU General Public License, версия 2 или новее</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="2203"/>
         <source>Error</source>
-        <translation type="unfinished">Ошибка</translation>
+        <translation>Ошибка</translation>
     </message>
 </context>
 <context>
@@ -8542,76 +3306,76 @@ Please select temperature calculation mode
     <message>
         <location filename="../src/unitsdialog.cpp" line="37"/>
         <source>Units</source>
-        <translation type="unfinished">Единицы измерения</translation>
+        <translation>Единицы измерения</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="46"/>
         <source>Category</source>
-        <translation type="unfinished">Категория</translation>
+        <translation>Категория</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="63"/>
         <location filename="../src/unitsdialog.cpp" line="560"/>
         <source>Unit</source>
-        <translation type="unfinished">Единица измерения</translation>
+        <translation>Единица измерения</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="84"/>
         <source>New…</source>
-        <translation type="unfinished">Новый…</translation>
+        <translation>Новая…</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="86"/>
         <source>Edit…</source>
-        <translation type="unfinished">Правка…</translation>
+        <translation>Правка…</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="87"/>
         <location filename="../src/unitsdialog.cpp" line="445"/>
         <location filename="../src/unitsdialog.cpp" line="448"/>
         <source>Deactivate</source>
-        <translation type="unfinished">Деактивировать</translation>
+        <translation>Деактивировать</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="88"/>
         <source>Delete</source>
-        <translation type="unfinished">Удалить</translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="90"/>
         <source>Convert</source>
-        <translation type="unfinished">Перевести</translation>
+        <translation>Перевести</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="91"/>
         <source>Insert</source>
-        <translation type="unfinished">Вставить</translation>
+        <translation>Вставить</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="450"/>
         <source>Activate</source>
-        <translation type="unfinished">Активировать</translation>
+        <translation>Активировать</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="636"/>
         <source>All</source>
         <comment>All units</comment>
-        <translation type="unfinished">Все</translation>
+        <translation>Все</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="679"/>
         <source>Uncategorized</source>
-        <translation type="unfinished">Без категорий</translation>
+        <translation>Без категорий</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="685"/>
         <source>User units</source>
-        <translation type="unfinished">Пользовательские единицы</translation>
+        <translation>Пользовательские единицы</translation>
     </message>
     <message>
         <location filename="../src/unitsdialog.cpp" line="692"/>
         <source>Inactive</source>
-        <translation type="unfinished">Неактивный</translation>
+        <translation>Неактивные</translation>
     </message>
 </context>
 <context>
@@ -8619,46 +3383,46 @@ Please select temperature calculation mode
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="30"/>
         <source>Name:</source>
-        <translation type="unfinished">Имя:</translation>
+        <translation>Имя:</translation>
     </message>
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="33"/>
         <source>Custom assumptions</source>
-        <translation type="unfinished">Собственные предположения</translation>
+        <translation>Собственные предположения</translation>
     </message>
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="36"/>
         <source>Type:</source>
-        <translation type="unfinished">Тип:</translation>
+        <translation>Тип:</translation>
     </message>
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="44"/>
         <source>Sign:</source>
-        <translation type="unfinished">Знак:</translation>
+        <translation>Знак:</translation>
     </message>
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="95"/>
         <location filename="../src/unknowneditdialog.cpp" line="127"/>
         <source>A unit or variable with the same name already exists.
 Do you want to overwrite it?</source>
-        <translation type="unfinished">Единица измерения или переменная или  с таким именем уже существует.
+        <translation>Единица измерения или переменная с таким именем уже существует.
 Вы хотите её перезаписать?</translation>
     </message>
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="169"/>
         <source>Edit Unknown Variable</source>
-        <translation type="unfinished">Изменить переменную неизвестного</translation>
+        <translation>Изменить переменную неизвестного</translation>
     </message>
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="182"/>
         <source>New Unknown Variable</source>
-        <translation type="unfinished">Новая переменная неизвестного</translation>
+        <translation>Новая переменная неизвестного</translation>
     </message>
     <message>
         <location filename="../src/unknowneditdialog.cpp" line="95"/>
         <location filename="../src/unknowneditdialog.cpp" line="127"/>
         <source>Question</source>
-        <translation type="unfinished">Вопрос</translation>
+        <translation>Вопрос</translation>
     </message>
 </context>
 <context>
@@ -8666,47 +3430,47 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="30"/>
         <source>Name:</source>
-        <translation type="unfinished">Имя:</translation>
+        <translation>Имя:</translation>
     </message>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="33"/>
         <source>Temporary</source>
-        <translation type="unfinished">Временный</translation>
+        <translation>Временная</translation>
     </message>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="45"/>
         <source>Value:</source>
-        <translation type="unfinished">Значение:</translation>
+        <translation>Значение:</translation>
     </message>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="47"/>
         <source>current result</source>
-        <translation type="unfinished">текущий результат</translation>
+        <translation>текущий результат</translation>
     </message>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="75"/>
         <location filename="../src/variableeditdialog.cpp" line="107"/>
         <source>A unit or variable with the same name already exists.
 Do you want to overwrite it?</source>
-        <translation type="unfinished">Единица измерения или переменная или  с таким именем уже существует.
+        <translation>Единица измерения или переменная с таким именем уже существует.
 Вы хотите её перезаписать?</translation>
     </message>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="179"/>
         <source>Edit Variable</source>
-        <translation type="unfinished">Изменить переменную</translation>
+        <translation>Изменить переменную</translation>
     </message>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="193"/>
         <location filename="../src/variableeditdialog.cpp" line="227"/>
         <source>New Variable</source>
-        <translation type="unfinished">Новая переменная</translation>
+        <translation>Новая переменная</translation>
     </message>
     <message>
         <location filename="../src/variableeditdialog.cpp" line="75"/>
         <location filename="../src/variableeditdialog.cpp" line="107"/>
         <source>Question</source>
-        <translation type="unfinished">Вопрос</translation>
+        <translation>Вопрос</translation>
     </message>
 </context>
 <context>
@@ -8714,171 +3478,172 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../src/variablesdialog.cpp" line="37"/>
         <source>Variables</source>
-        <translation type="unfinished">Переменные</translation>
+        <translation>Переменные</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="46"/>
         <source>Category</source>
-        <translation type="unfinished">Категория</translation>
+        <translation>Категория</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="63"/>
         <location filename="../src/variablesdialog.cpp" line="430"/>
         <source>Variable</source>
-        <translation type="unfinished">Переменная</translation>
+        <translation>Переменная</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="84"/>
         <source>New</source>
-        <translation type="unfinished">Новый</translation>
+        <translatorcomment>Новая переменная/константа/матрица</translatorcomment>
+        <translation>Новая</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="86"/>
         <source>Variable/Constant…</source>
-        <translation type="unfinished">Переменная/константа…</translation>
+        <translation>Переменная/константа…</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="87"/>
         <source>Unknown Variable…</source>
-        <translation type="unfinished">Переменная неизвестного…</translation>
+        <translation>Переменная неизвестного…</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="88"/>
         <source>Matrix…</source>
-        <translation type="unfinished">Матрица…</translation>
+        <translation>Матрица…</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="90"/>
         <source>Edit…</source>
-        <translation type="unfinished">Правка…</translation>
+        <translation>Правка…</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="91"/>
         <source>Export…</source>
-        <translation type="unfinished">Экспортировать…</translation>
+        <translation>Экспортировать…</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="92"/>
         <location filename="../src/variablesdialog.cpp" line="364"/>
         <location filename="../src/variablesdialog.cpp" line="367"/>
         <source>Deactivate</source>
-        <translation type="unfinished">Деактивировать</translation>
+        <translation>Деактивировать</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="93"/>
         <source>Delete</source>
-        <translation type="unfinished">Удалить</translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="95"/>
         <source>Insert</source>
-        <translation type="unfinished">Вставить</translation>
+        <translation>Вставить</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="315"/>
         <source>a matrix</source>
-        <translation type="unfinished">матрица</translation>
+        <translation>матрица</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="317"/>
         <source>a vector</source>
-        <translation type="unfinished">вектор</translation>
+        <translation>вектор</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="335"/>
         <source>positive</source>
-        <translation type="unfinished">положительное</translation>
+        <translation>положительное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="336"/>
         <source>non-positive</source>
-        <translation type="unfinished">не положительное</translation>
+        <translation>не положительное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="337"/>
         <source>negative</source>
-        <translation type="unfinished">отрицательное</translation>
+        <translation>отрицательное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="338"/>
         <source>non-negative</source>
-        <translation type="unfinished">неотрицательное</translation>
+        <translation>неотрицательное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="339"/>
         <source>non-zero</source>
-        <translation type="unfinished">ненулевое</translation>
+        <translation>ненулевое</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="345"/>
         <source>integer</source>
-        <translation type="unfinished">целое</translation>
+        <translation>целое</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="346"/>
         <source>boolean</source>
-        <translation type="unfinished">логическое</translation>
+        <translation>логическое</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="347"/>
         <source>rational</source>
-        <translation type="unfinished">рациональное</translation>
+        <translation>рациональное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="348"/>
         <source>real</source>
-        <translation type="unfinished">вещественное</translation>
+        <translation>вещественное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="349"/>
         <source>complex</source>
-        <translation type="unfinished">комплексное</translation>
+        <translation>комплексное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="350"/>
         <source>number</source>
-        <translation type="unfinished">число</translation>
+        <translation>число</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="351"/>
         <source>not matrix</source>
-        <translation type="unfinished">не матрица</translation>
+        <translation>не матрица</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="354"/>
         <source>unknown</source>
-        <translation type="unfinished">неизвестное</translation>
+        <translation>неизвестное</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="357"/>
         <source>Default assumptions</source>
-        <translation type="unfinished">Предположения по умолчанию</translation>
+        <translation>Предположения по умолчанию</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="369"/>
         <source>Activate</source>
-        <translation type="unfinished">Активировать</translation>
+        <translation>Активировать</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="487"/>
         <source>All</source>
         <comment>All variables</comment>
-        <translation type="unfinished">Все</translation>
+        <translation>Все</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="530"/>
         <source>Uncategorized</source>
-        <translation type="unfinished">Без категорий</translation>
+        <translation>Без категорий</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="536"/>
         <source>User variables</source>
-        <translation type="unfinished">Пользовательские переменные</translation>
+        <translation>Пользовательские переменные</translation>
     </message>
     <message>
         <location filename="../src/variablesdialog.cpp" line="543"/>
         <source>Inactive</source>
-        <translation type="unfinished">Неактивный</translation>
+        <translation>Неактивные</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
- Check and fix Russian translation.
- Use plural forms in the SpinBox suffix of auto-exchange-update period.
- Drop space in "ms" translation.
