### PR TITLE
Add translations files for fix build on macOS

### DIFF
--- a/qalculate-qt.pro
+++ b/qalculate-qt.pro
@@ -80,7 +80,7 @@ TRANSLATIONS = 	translations/qalculate-qt_ca.ts \
 	}
 }
 
-unix:!equals(COMPILE_RESOURCES,"yes"):!android:!macx {
+unix:!equals(COMPILE_RESOURCES,"yes"):!android:macx {
 
 	target.path = $$PREFIX/bin
 


### PR DESCRIPTION
This change fixes the following bug during project build:

```
No rule to make target `translations/qalculate-qt_zh_CN.qm', needed by `qrc_translations.cpp'.
```