### PR TITLE
Fixed typo in german translation

### DIFF
--- a/translations/qalculate-qt_de.ts
+++ b/translations/qalculate-qt_de.ts
@@ -10460,7 +10460,7 @@ Möchten Sie die aktuelle Aktion (%1) ersetzen?</translation>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="672"/>
         <source>Custom</source>
-        <translation type="unfinished">Bentutzerdefiniert</translation>
+        <translation type="unfinished">Benutzerdefiniert</translation>
     </message>
     <message>
         <location filename="../src/qalculatewindow.cpp" line="674"/>


### PR DESCRIPTION
The german translation for the custom keypad mode had a typo. To verify, search for anything that contains the word "custom" in the german language file. The spelling is always _benutzerdefiniert_.

Have a nice day :)