### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/data/io.github.Qalculate.qalculate-qt.metainfo.xml
+++ b/data/io.github.Qalculate.qalculate-qt.metainfo.xml
@@ -55,7 +55,9 @@
  <url type="help">https://qalculate.github.io/manual/index.html</url>
  <url type="donation">https://www.paypal.me/HannaKnutsson</url>
  <url type="translate">https://github.com/Qalculate/libqalculate/blob/master/README.translate</url>
- <developer_name>Hanna Knutsson</developer_name>
+ <developer>
+  <name>Hanna Knutsson</name>
+ </developer>
  <content_rating type="oars-1.0"/>
  <kudos>
   <kudo>HiDpiIcon</kudo>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: io.github.Qalculate.qalculate-qt:58: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

I: io.github.Qalculate.qalculate-qt:62: nonstandard-gnome-extension kudos
   This tag is a GNOME-specific extension to AppStream and not part of the official specification.
   Do not expect it to work in all implementations and in all software centers.

✔ Validation was successful: infos: 2, pedantic: 1
```