### PR TITLE
Change developer id in metadata to all lower-case

### DIFF
--- a/data/io.github.Qalculate.qalculate-qt.metainfo.xml
+++ b/data/io.github.Qalculate.qalculate-qt.metainfo.xml
@@ -55,7 +55,7 @@
  <url type="help">https://qalculate.github.io/manual/index.html</url>
  <url type="donation">https://www.paypal.me/HannaKnutsson</url>
  <url type="translate">https://github.com/Qalculate/libqalculate/blob/master/README.translate</url>
- <developer id="io.github.Qalculate">
+ <developer id="io.github.qalculate">
   <name>Hanna Knutsson</name>
  </developer>
  <content_rating type="oars-1.0"/>


### PR DESCRIPTION
AppStream 1.0.2 wants the id to contain only lower-case ASCII leters, numbers, and punctuation.

Fixes #119.