### PR TITLE
Fix the missing window icon when running under Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,7 @@ int main(int argc, char **argv) {
 	app.setApplicationName("qalculate-qt");
 	app.setApplicationDisplayName("Qalculate!");
 	app.setOrganizationName("qalculate");
+	app.setDesktopFileName("io.github.Qalculate.qalculate-qt");
 	app.setApplicationVersion("5.0.0");
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	app.setAttribute(Qt::AA_UseHighDpiPixmaps);


### PR DESCRIPTION
Currently, when running under Wayland, the window icon will fallback to the default Wayland icon.
Setting the desktop filename can solve this problem.

Before:
![Screenshot_20240425_165247](https://github.com/Qalculate/qalculate-qt/assets/71180087/9993721b-a5a7-4941-a52b-15e18b297e61)

After:
![Screenshot_20240425_165309](https://github.com/Qalculate/qalculate-qt/assets/71180087/cd51161a-0a2c-4c1d-97b4-40ba14b638de)
