### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/src/expressionedit.cpp
+++ b/src/expressionedit.cpp
@@ -983,8 +983,8 @@ bool ExpressionEdit::eventFilter(QObject *o, QEvent *e) {
 						sourceModel->appendRow(items);}
 
 #define COMPLETION_APPEND_FLAG(x, y, y2, z, p)	if(!QFile::exists(":/data/flags/" + QString::fromStdString(u->referenceName() + ".png"))) {COMPLETION_APPEND_2(x, y, y2, z, p)} \
-						else if(flagheight <= 0) {COMPLETION_APPEND_2(x, QString("%1&nbsp;&nbsp;<img src=\":/data/flags/%2\"/>").arg(y).arg(QString::fromStdString(u->referenceName())), QString("%1<img src=\":/data/flags/%2\"/>").arg(y2).arg(QString::fromStdString(u->referenceName())), z, p)} \
-						else {COMPLETION_APPEND_2(x, QString("%1&nbsp;&nbsp;<img height=\"%2\" src=\":/data/flags/%3\"/>").arg(y).arg(flagheight).arg(QString::fromStdString(u->referenceName())), QString("%1<img src=\":/data/flags/%2\"/>").arg(y2).arg(QString::fromStdString(u->referenceName())), z, p)}
+						else if(flagheight <= 0) {COMPLETION_APPEND_2(x, QStringLiteral("%1&nbsp;&nbsp;<img src=\":/data/flags/%2\"/>").arg(y).arg(QString::fromStdString(u->referenceName())), QStringLiteral("%1<img src=\":/data/flags/%2\"/>").arg(y2).arg(QString::fromStdString(u->referenceName())), z, p)} \
+						else {COMPLETION_APPEND_2(x, QStringLiteral("%1&nbsp;&nbsp;<img height=\"%2\" src=\":/data/flags/%3\"/>").arg(y).arg(flagheight).arg(QString::fromStdString(u->referenceName())), QStringLiteral("%1<img src=\":/data/flags/%2\"/>").arg(y2).arg(QString::fromStdString(u->referenceName())), z, p)}
 
 #define MAX_COMPLETION_LENGTH_1 25
 #define MAX_COMPLETION_LENGTH_2 25

--- a/src/functionsdialog.cpp
+++ b/src/functionsdialog.cpp
@@ -193,7 +193,7 @@ void FunctionsDialog::newClicked() {
 				new QTreeWidgetItem(list.isEmpty() ? categoriesView->topLevelItem(2) : list[0], l);
 			}
 		} else if(f->category() != CALCULATOR->temporaryCategory()) {
-			QList<QTreeWidgetItem*> list = categoriesView->findItems(QString("/") + QString::fromStdString(f->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
+			QList<QTreeWidgetItem*> list = categoriesView->findItems(QStringLiteral("/") + QString::fromStdString(f->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
 			if(list.isEmpty()) {
 				if(selected_category != "All") selected_category = "User items";
 				updateFunctions();
@@ -251,7 +251,7 @@ void FunctionsDialog::editClicked() {
 				new QTreeWidgetItem(list.isEmpty() ? categoriesView->topLevelItem(2) : list[0], l);
 			}
 		} else if(f->category() != CALCULATOR->temporaryCategory()) {
-			QList<QTreeWidgetItem*> list = categoriesView->findItems(QString("/") + QString::fromStdString(f->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
+			QList<QTreeWidgetItem*> list = categoriesView->findItems(QStringLiteral("/") + QString::fromStdString(f->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
 			if(list.isEmpty()) {
 				if(selected_category != "All") selected_category = "User items";
 				updateFunctions();

--- a/src/historyview.cpp
+++ b/src/historyview.cpp
@@ -408,7 +408,7 @@ void HistoryView::clearTemporary() {
 
 bool HistoryView::testTemporaryResultLength(const std::string &str) {
 	QFontMetrics fm(font());
-	return fm.boundingRect(QString("#9999") + "= " + unhtmlize(QString::fromStdString(str))).width() < width() * 1.65;
+	return fm.boundingRect(QStringLiteral("#9999") + "= " + unhtmlize(QString::fromStdString(str))).width() < width() * 1.65;
 }
 
 void HistoryView::addResult(std::vector<std::string> values, std::string expression, bool pexact, std::string parse, int exact, bool dual_approx, const QString &image, bool *implicit_warning, int initial_load, size_t index, bool temporary) {
@@ -466,8 +466,8 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 	PASTE_H
 	QString str;
 	if(!expression.empty() || !parse.empty()) {
-		if(initial_load && index != settings->v_expression.size() - 1) str += QString("<tr><td colspan=\"2\" style=\"padding-bottom: %1 px; padding-top: %3px; border-top: 1px dashed %2; text-align:left\">").arg(paste_h / 4).arg(text_color.name()).arg(paste_h / 2);
-		else str += QString("<tr><td colspan=\"2\" style=\"padding-bottom: %1 px; padding-top: 0px; border-top: 0px none %2; text-align:left\">").arg(paste_h / 4).arg(text_color.name());
+		if(initial_load && index != settings->v_expression.size() - 1) str += QStringLiteral("<tr><td colspan=\"2\" style=\"padding-bottom: %1 px; padding-top: %3px; border-top: 1px dashed %2; text-align:left\">").arg(paste_h / 4).arg(text_color.name()).arg(paste_h / 2);
+		else str += QStringLiteral("<tr><td colspan=\"2\" style=\"padding-bottom: %1 px; padding-top: 0px; border-top: 0px none %2; text-align:left\">").arg(paste_h / 4).arg(text_color.name());
 		if(temporary) {
 			parse_tmp = parse;
 			result_tmp = (values.empty() ? "" : values[0]);
@@ -494,12 +494,12 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 		gsub("</i>", "<img src=\"data://img1px.png\" width=\"1\"/></i>", parse);
 		if(!temporary && !expression.empty() && (settings->history_expression_type > 0 || parse.empty())) {
 			if(!parse.empty() && settings->history_expression_type > 1 && parse != expression) {
-				str += QString("<a name=\"e%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
+				str += QStringLiteral("<a name=\"e%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
 				str += QString::fromStdString(expression).toHtmlEscaped();
 				str += "</a>";
 				if(settings->color == 2) str += "&nbsp; <i style=\"color: #AAAAAA\">";
 				else str += "&nbsp; <i style=\"color: #666666\">";
-				str += QString("<a name=\"a%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
+				str += QStringLiteral("<a name=\"a%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
 				if(pexact) str += "= ";
 				else str += SIGN_ALMOST_EQUAL " ";
 				if(!settings->colorize_result) str += QString::fromStdString(uncolorize(parse, false));
@@ -507,13 +507,13 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 				str += "</a>";
 				str += "</i>";
 			} else {
-				str += QString("<a name=\"%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
+				str += QStringLiteral("<a name=\"%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
 				str += QString::fromStdString(expression).toHtmlEscaped();
 				str += "</a>";
 			}
 		} else {
 			if(temporary) str += "<a name=\"TP\" style=\"text-decoration: none\">";
-			else str += QString("<a name=\"%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
+			else str += QStringLiteral("<a name=\"%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
 			if(!pexact) str += SIGN_ALMOST_EQUAL " ";
 			if(!settings->colorize_result) str += QString::fromStdString(uncolorize(parse, false));
 			else str += QString::fromStdString(parse);
@@ -522,7 +522,7 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 				str += "&nbsp;&nbsp;&nbsp; ";
 				if(settings->color == 2) str += "<i style=\"color: #AAAAAA\">";
 				else str += "<i style=\"color: #666666\">";
-				str += QString("<a name=\"e%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
+				str += QStringLiteral("<a name=\"e%1\" style=\"text-decoration: none\">").arg(initial_load ? (int) index : settings->v_expression.size() - 1);
 				str += QString::fromStdString(replace_parse_colors(expression));
 				str += "</a>";
 				str += "</i>";
@@ -539,7 +539,7 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 		}
 		if(temporary) {
 			temporary_error = serror;
-			if(!serror.isEmpty()) str += QString("<img src=\"data://img1px.png\" width=\"2\"/><img valign=\"top\" src=\"%1\" height=\"%2\" alt=\"temporary_error\"/>").arg(":/icons/actions/scalable/warning.svg").arg(fm.ascent());
+			if(!serror.isEmpty()) str += QStringLiteral("<img src=\"data://img1px.png\" width=\"2\"/><img valign=\"top\" src=\"%1\" height=\"%2\" alt=\"temporary_error\"/>").arg(":/icons/actions/scalable/warning.svg").arg(fm.ascent());
 		}
 		str += "</td></tr>";
 	} else if(!initial_load && !settings->v_result.empty()) {
@@ -580,9 +580,9 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 			}
 			QString sref;
 			if(settings->color == 2) {
-				sref = QString("<a href=\"#%1:%2:%3\" style=\"text-decoration: none; text-align:left; color: #AAAAAA\">#%1</a>").arg(i_answer).arg(initial_load ? (int) index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
+				sref = QStringLiteral("<a href=\"#%1:%2:%3\" style=\"text-decoration: none; text-align:left; color: #AAAAAA\">#%1</a>").arg(i_answer).arg(initial_load ? (int) index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
 			} else {
-				sref = QString("<a href=\"#%1:%2:%3\" style=\"text-decoration: none; text-align:left; color: #585858\">#%1</a>").arg(i_answer).arg(initial_load ? (int) index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
+				sref = QStringLiteral("<a href=\"#%1:%2:%3\" style=\"text-decoration: none; text-align:left; color: #585858\">#%1</a>").arg(i_answer).arg(initial_load ? (int) index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
 			}
 			bool b = true;
 			if(initial_load) {
@@ -610,7 +610,7 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 			str += "; font-size:x-large";
 			gsub("</i>", "<img src=\"data://img1px.png\" width=\"2\"/></i>", values[i]);
 		}
-		if((!expression.empty() || !parse.empty()) && i == values.size() - 1) str += QString("; padding-bottom: %1 px").arg(paste_h / 4);
+		if((!expression.empty() || !parse.empty()) && i == values.size() - 1) str += QStringLiteral("; padding-bottom: %1 px").arg(paste_h / 4);
 		str += "\">";
 		int b_exact = 1;
 		if(initial_load) {
@@ -622,8 +622,8 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 		if(temporary && !values[i].empty()) {
 			str += "<a name=\"TR\" style=\"text-decoration: none\">";
 		} else if(!temporary) {
-			if(i_answer == 0) str += QString("<a name=\"%1:%2\" style=\"text-decoration: none\">").arg(initial_load ? index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
-			else str += QString("<a name=\"p%1:%2:%3\" style=\"text-decoration: none\">").arg(i_answer).arg(initial_load ? index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
+			if(i_answer == 0) str += QStringLiteral("<a name=\"%1:%2\" style=\"text-decoration: none\">").arg(initial_load ? index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
+			else str += QStringLiteral("<a name=\"p%1:%2:%3\" style=\"text-decoration: none\">").arg(i_answer).arg(initial_load ? index : settings->v_expression.size() - 1).arg(initial_load ? (int) i : settings->v_result[settings->v_result.size() - 1].size() - i - 1);
 		}
 		if(!temporary || !values[i].empty()) {
 			if(b_exact > 0) str += "= ";
@@ -632,7 +632,7 @@ void HistoryView::addResult(std::vector<std::string> values, std::string express
 		if(!settings->colorize_result) str += QString::fromStdString(uncolorize(values[i], false));
 		else str += QString::fromStdString(values[i]);
 		if(!image.isEmpty() && i == values.size() - 1 && w * 1.85 + w_number + fm.ascent() <= width()) {
-			str += QString("<img src=\"data://img1px.png\" width=\"2\"/><img valign=\"top\" src=\"%1\" height=\"%2\"").arg(image).arg(fm.ascent());
+			str += QStringLiteral("<img src=\"data://img1px.png\" width=\"2\"/><img valign=\"top\" src=\"%1\" height=\"%2\"").arg(image).arg(fm.ascent());
 			CALCULATOR->setExchangeRatesUsed(-100);
 			int i = CALCULATOR->exchangeRatesUsed();
 			CALCULATOR->setExchangeRatesUsed(-100);

--- a/src/keypadwidget.cpp
+++ b/src/keypadwidget.cpp
@@ -1075,7 +1075,7 @@ void KeypadWidget::currentCustomActionChanged(QTreeWidgetItem *item, QTreeWidget
 			valueEdit->addItems(citems);
 		} else if(i == SHORTCUT_TYPE_OPERATOR) {
 			QStringList citems;
-			citems << "+" << (settings->printops.use_unicode_signs ? SIGN_MINUS : "-") << settings->multiplicationSign(false) << settings->divisionSign(false) << "^" << ".+" << (QString(".") + (settings->printops.use_unicode_signs ? SIGN_MINUS : "-")) << (QString(".") + settings->multiplicationSign(false)) << (QString(".") + settings->divisionSign(false)) << ".^" << "mod" << "rem" << "//" << "&" << "|" << "<<" << ">>" << "&&" << "||" << "xor" << "=" << SIGN_NOT_EQUAL << "<" << SIGN_LESS_OR_EQUAL << SIGN_GREATER_OR_EQUAL << ">";
+			citems << "+" << (settings->printops.use_unicode_signs ? SIGN_MINUS : "-") << settings->multiplicationSign(false) << settings->divisionSign(false) << "^" << ".+" << (QStringLiteral(".") + (settings->printops.use_unicode_signs ? SIGN_MINUS : "-")) << (QStringLiteral(".") + settings->multiplicationSign(false)) << (QStringLiteral(".") + settings->divisionSign(false)) << ".^" << "mod" << "rem" << "//" << "&" << "|" << "<<" << ">>" << "&&" << "||" << "xor" << "=" << SIGN_NOT_EQUAL << "<" << SIGN_LESS_OR_EQUAL << SIGN_GREATER_OR_EQUAL << ">";
 			valueEdit->addItems(citems);
 		} else if(i == SHORTCUT_TYPE_COPY_RESULT) {
 			settings->updateActionValueTexts();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 		if(lockFile.error() == QLockFile::LockFailedError) {
 			bool ami_changed = false;
 			if(settings->allow_multiple_instances < 0 && parser->value(fOption).isEmpty() && parser->value(wOption).isEmpty() && parser->positionalArguments().isEmpty()) {
-				settings->allow_multiple_instances = (QMessageBox::question(NULL, QString("Allow multiple instances?"), QApplication::tr("By default, only one instance (one main window) of %1 is allowed.\n\nIf multiple instances are opened simultaneously, only the definitions (variables, functions, etc.), mode, preferences, and history of the last closed window will be saved.\n\nDo you, despite this, want to change the default behavior and allow multiple simultaneous instances?").arg("Qalculate!"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes);
+				settings->allow_multiple_instances = (QMessageBox::question(NULL, QStringLiteral("Allow multiple instances?"), QApplication::tr("By default, only one instance (one main window) of %1 is allowed.\n\nIf multiple instances are opened simultaneously, only the definitions (variables, functions, etc.), mode, preferences, and history of the last closed window will be saved.\n\nDo you, despite this, want to change the default behavior and allow multiple simultaneous instances?").arg("Qalculate!"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes);
 				ami_changed = true;
 				if(settings->allow_multiple_instances) {
 					QLocalSocket socket;

--- a/src/periodictabledialog.cpp
+++ b/src/periodictabledialog.cpp
@@ -197,10 +197,10 @@ void PeriodicTableDialog::elementClicked() {
 		case TRANSACTINIDES: {group_name = tr("Unknown chemical properties"); break;}
 		default: {group_name = tr("Unknown"); break;}
 	}
-	grid->addWidget(new QLabel(QString("<div style=\"font-size: large\">%1</div>").arg(QString::fromStdString(e->getProperty(p_number))), dialog), 0, 0, 1, 3, Qt::AlignRight);
-	grid->addWidget(new QLabel(QString("<div style=\"font-size: xx-large\">%1</div>").arg(QString::fromStdString(e->getProperty(p_symbol))), dialog), 1, 0, 1, 3);
-	grid->addWidget(new QLabel(QString("<div style=\"font-size: x-large\">%1</div>").arg(QString::fromStdString(e->getProperty(p_name))), dialog), 2, 0, 1, 3);
-	grid->addWidget(new QLabel(QString("<div style=\"font-weight: bold\">%1</div>").arg(tr("%1:").arg(QString::fromStdString(p_class->title()))), dialog), 3, 0);
+	grid->addWidget(new QLabel(QStringLiteral("<div style=\"font-size: large\">%1</div>").arg(QString::fromStdString(e->getProperty(p_number))), dialog), 0, 0, 1, 3, Qt::AlignRight);
+	grid->addWidget(new QLabel(QStringLiteral("<div style=\"font-size: xx-large\">%1</div>").arg(QString::fromStdString(e->getProperty(p_symbol))), dialog), 1, 0, 1, 3);
+	grid->addWidget(new QLabel(QStringLiteral("<div style=\"font-size: x-large\">%1</div>").arg(QString::fromStdString(e->getProperty(p_name))), dialog), 2, 0, 1, 3);
+	grid->addWidget(new QLabel(QStringLiteral("<div style=\"font-weight: bold\">%1</div>").arg(tr("%1:").arg(QString::fromStdString(p_class->title()))), dialog), 3, 0);
 	grid->addWidget(new QLabel(group_name, dialog), 3, 1);
 	DataPropertyIter it;
 	DataProperty *dp = ds->getFirstProperty(&it);
@@ -209,7 +209,7 @@ void PeriodicTableDialog::elementClicked() {
 		if(!dp->isHidden() && dp != p_number && dp != p_class && dp != p_symbol && dp != p_name) {
 			std::string sval = e->getPropertyDisplayString(dp);
 			if(!sval.empty()) {
-				grid->addWidget(new QLabel(QString("<div style=\"font-weight: bold\">%1</div>").arg(tr("%1:").arg(QString::fromStdString(dp->title()))), dialog), row, 0);
+				grid->addWidget(new QLabel(QStringLiteral("<div style=\"font-weight: bold\">%1</div>").arg(tr("%1:").arg(QString::fromStdString(dp->title()))), dialog), row, 0);
 				grid->addWidget(new QLabel(QString::fromStdString(sval), dialog), row, 1);
 				QPushButton *button = new QPushButton(LOAD_ICON("edit-paste"), QString(), dialog);
 				grid->addWidget(button, row, 2);

--- a/src/qalculatewindow.cpp
+++ b/src/qalculatewindow.cpp
@@ -1157,35 +1157,35 @@ void QalculateWindow::keyboardShortcutRemoved(keyboard_shortcut *ks) {
 	shortcuts.removeAll(QKeySequence::fromString(ks->key));
 	ks->action->setShortcuts(shortcuts);
 	if(ks->type[0] == SHORTCUT_TYPE_PLOT && plotAction_t) {
-		plotAction_t->setToolTip(tr("Plot Functions/Data") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		plotAction_t->setToolTip(tr("Plot Functions/Data") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_STORE) {
-		storeAction_t->setToolTip(tr("Store") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
+		storeAction_t->setToolTip(tr("Store") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
 	} else if(ks->type[0] == SHORTCUT_TYPE_MANAGE_UNITS) {
-		unitsAction_t->setToolTip(tr("Units") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
+		unitsAction_t->setToolTip(tr("Units") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
 	} else if(ks->type[0] == SHORTCUT_TYPE_MANAGE_FUNCTIONS) {
-		functionsAction_t->setToolTip(tr("Functions") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
+		functionsAction_t->setToolTip(tr("Functions") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
 	} else if(ks->type[0] == SHORTCUT_TYPE_NUMBER_BASES) {
-		basesAction->setToolTip(tr("Number Bases") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		basesAction->setToolTip(tr("Number Bases") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_CONVERT) {
-		toAction_t->setToolTip(tr("Convert") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		toAction_t->setToolTip(tr("Convert") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_MODE) {
-		modeAction_t->setToolTip(tr("Mode") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		modeAction_t->setToolTip(tr("Mode") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_MENU) {
-		menuAction_t->setToolTip(tr("Menu") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		menuAction_t->setToolTip(tr("Menu") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_RPN_UP) {
-		rpnUpAction->setToolTip(tr("Rotate the stack or move the selected register up") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		rpnUpAction->setToolTip(tr("Rotate the stack or move the selected register up") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_RPN_DOWN) {
-		rpnDownAction->setToolTip(tr("Rotate the stack or move the selected register down") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		rpnDownAction->setToolTip(tr("Rotate the stack or move the selected register down") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_RPN_SWAP) {
-		rpnSwapAction->setToolTip(tr("Swap the top two values or move the selected value to the top of the stack") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		rpnSwapAction->setToolTip(tr("Swap the top two values or move the selected value to the top of the stack") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_RPN_DELETE) {
-		rpnDeleteAction->setToolTip(tr("Delete the top or selected value") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		rpnDeleteAction->setToolTip(tr("Delete the top or selected value") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_RPN_LASTX) {
-		rpnLastxAction->setToolTip(tr("Enter the top value from before the last numeric operation") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		rpnLastxAction->setToolTip(tr("Enter the top value from before the last numeric operation") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_RPN_COPY) {
-		rpnCopyAction->setToolTip(tr("Copy the selected or top value to the top of the stack") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		rpnCopyAction->setToolTip(tr("Copy the selected or top value to the top of the stack") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	} else if(ks->type[0] == SHORTCUT_TYPE_RPN_CLEAR) {
-		rpnClearAction->setToolTip(tr("Clear the RPN stack") + (shortcuts.isEmpty() ? QString() : QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
+		rpnClearAction->setToolTip(tr("Clear the RPN stack") + (shortcuts.isEmpty() ? QString() : QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText))));
 	}
 }
 void QalculateWindow::keyboardShortcutAdded(keyboard_shortcut *ks) {
@@ -1244,38 +1244,38 @@ void QalculateWindow::keyboardShortcutAdded(keyboard_shortcut *ks) {
 		addAction(action);
 		action->setShortcuts(shortcuts);
 		if(ks->type[0] == SHORTCUT_TYPE_PLOT) {
-			if(plotAction_t) plotAction_t->setToolTip(tr("Plot Functions/Data") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			if(plotAction_t) plotAction_t->setToolTip(tr("Plot Functions/Data") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_MANAGE_UNITS) {
-			unitsAction_t->setToolTip(tr("Units") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
+			unitsAction_t->setToolTip(tr("Units") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
 		} else if(ks->type[0] == SHORTCUT_TYPE_MANAGE_FUNCTIONS) {
-			functionsAction_t->setToolTip(tr("Functions") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
+			functionsAction_t->setToolTip(tr("Functions") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
 		} else if(ks->type[0] == SHORTCUT_TYPE_NUMBER_BASES) {
-			basesAction->setToolTip(tr("Number Bases") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			basesAction->setToolTip(tr("Number Bases") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_RPN_UP) {
-			rpnUpAction->setToolTip(tr("Rotate the stack or move the selected register up") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			rpnUpAction->setToolTip(tr("Rotate the stack or move the selected register up") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_RPN_DOWN) {
-			rpnDownAction->setToolTip(tr("Rotate the stack or move the selected register down") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			rpnDownAction->setToolTip(tr("Rotate the stack or move the selected register down") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_RPN_SWAP) {
-			rpnSwapAction->setToolTip(tr("Swap the top two values or move the selected value to the top of the stack") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			rpnSwapAction->setToolTip(tr("Swap the top two values or move the selected value to the top of the stack") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_RPN_DELETE) {
-			rpnDeleteAction->setToolTip(tr("Delete the top or selected value") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			rpnDeleteAction->setToolTip(tr("Delete the top or selected value") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_RPN_LASTX) {
-			rpnLastxAction->setToolTip(tr("Enter the top value from before the last numeric operation") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			rpnLastxAction->setToolTip(tr("Enter the top value from before the last numeric operation") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_RPN_COPY) {
-			rpnCopyAction->setToolTip(tr("Copy the selected or top value to the top of the stack") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			rpnCopyAction->setToolTip(tr("Copy the selected or top value to the top of the stack") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_RPN_CLEAR) {
-			rpnClearAction->setToolTip(tr("Clear the RPN stack") + QString(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
+			rpnClearAction->setToolTip(tr("Clear the RPN stack") + QStringLiteral(" (%1)").arg(shortcuts[0].toString(QKeySequence::NativeText)));
 		}
 	} else {
 		if(ks->type[0] == SHORTCUT_TYPE_MODE) {
-			modeAction_t->setToolTip(tr("Mode") + QString(" (%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)));
+			modeAction_t->setToolTip(tr("Mode") + QStringLiteral(" (%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_MENU) {
-			menuAction_t->setToolTip(tr("Menu") + QString(" (%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)));
+			menuAction_t->setToolTip(tr("Menu") + QStringLiteral(" (%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)));
 		} else if(ks->type[0] == SHORTCUT_TYPE_STORE) {
-			storeAction_t->setToolTip(tr("Store") + QString("(%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
+			storeAction_t->setToolTip(tr("Store") + QStringLiteral("(%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)) + "<br><br>" + tr("<i>Right-click/long press</i>: %1").arg(tr("Open menu")));
 		}
 		if(ks->type.size() == 1 && ks->type[0] == SHORTCUT_TYPE_CONVERT) {
-			toAction_t->setToolTip(tr("Convert") + QString(" (%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)));
+			toAction_t->setToolTip(tr("Convert") + QStringLiteral(" (%1)").arg(QKeySequence::fromString(ks->key).toString(QKeySequence::NativeText)));
 		}
 		ks->new_action = true;
 		action = new QAction(this);
@@ -2792,12 +2792,12 @@ void QalculateWindow::onInsertTextRequested(std::string str) {
 	expressionEdit->blockCompletion(false);
 }
 void QalculateWindow::showAbout() {
-	QMessageBox::about(this, tr("About %1").arg(qApp->applicationDisplayName()), QString("<font size=+2><b>%1 v%4</b></font><br><font size=+1>%2</font><br><font size=+1><i><a href=\"https://qalculate.github.io/\">https://qalculate.github.io/</a></i></font><br><br>Copyright © 2003-2007, 2008, 2016-2024 Hanna Knutsson<br>%3").arg(qApp->applicationDisplayName()).arg(tr("Powerful and easy to use calculator")).arg(tr("License: GNU General Public License version 2 or later")).arg(qApp->applicationVersion()));
+	QMessageBox::about(this, tr("About %1").arg(qApp->applicationDisplayName()), QStringLiteral("<font size=+2><b>%1 v%4</b></font><br><font size=+1>%2</font><br><font size=+1><i><a href=\"https://qalculate.github.io/\">https://qalculate.github.io/</a></i></font><br><br>Copyright © 2003-2007, 2008, 2016-2024 Hanna Knutsson<br>%3").arg(qApp->applicationDisplayName()).arg(tr("Powerful and easy to use calculator")).arg(tr("License: GNU General Public License version 2 or later")).arg(qApp->applicationVersion()));
 }
 void QalculateWindow::onInsertValueRequested(int i) {
 	expressionEdit->blockCompletion();
 	Number nr(i, 1, 0);
-	expressionEdit->insertText(QString("%1(%2)").arg(QString::fromStdString(settings->f_answer->preferredInputName(settings->printops.abbreviate_names, settings->printops.use_unicode_signs, false, false, &can_display_unicode_string_function, (void*) expressionEdit).formattedName(TYPE_FUNCTION, true))).arg(QString::fromStdString(print_with_evalops(nr))));
+	expressionEdit->insertText(QStringLiteral("%1(%2)").arg(QString::fromStdString(settings->f_answer->preferredInputName(settings->printops.abbreviate_names, settings->printops.use_unicode_signs, false, false, &can_display_unicode_string_function, (void*) expressionEdit).formattedName(TYPE_FUNCTION, true))).arg(QString::fromStdString(print_with_evalops(nr))));
 	if(!expressionEdit->hasFocus()) expressionEdit->setFocus();
 	expressionEdit->blockCompletion(false);
 }
@@ -6111,7 +6111,7 @@ void QalculateWindow::updateResultBases() {
 						} else if(sbin_i[i2] == '<') {
 							inhtml = false;
 						} else if(!inhtml && (sbin_i[i2] == '0' || sbin_i[i2] == '1')) {
-							sbin_i.replace(i2, 1, QString("<a href=\"%1\" style=\"text-decoration: none; color: %3\">%2</a>").arg(n).arg(sbin_i[i2]).arg(link_color));
+							sbin_i.replace(i2, 1, QStringLiteral("<a href=\"%1\" style=\"text-decoration: none; color: %3\">%2</a>").arg(n).arg(sbin_i[i2]).arg(link_color));
 							n++;
 						}
 					}
@@ -8522,7 +8522,7 @@ void QalculateWindow::currentShortcutActionChanged() {
 			shortcutActionValueEdit->addItems(citems);
 		} else if(i == SHORTCUT_TYPE_OPERATOR) {
 			QStringList citems;
-			citems << "+" << (settings->printops.use_unicode_signs ? SIGN_MINUS : "-") << settings->multiplicationSign(false) << settings->divisionSign(false) << "^" << ".+" << (QString(".") + (settings->printops.use_unicode_signs ? SIGN_MINUS : "-")) << (QString(".") + settings->multiplicationSign(false)) << (QString(".") + settings->divisionSign(false)) << ".^" << "mod" << "rem" << "//" << "&" << "|" << "<<" << ">>" << "&&" << "||" << "xor" << "=" << SIGN_NOT_EQUAL << "<" << SIGN_LESS_OR_EQUAL << SIGN_GREATER_OR_EQUAL << ">";
+			citems << "+" << (settings->printops.use_unicode_signs ? SIGN_MINUS : "-") << settings->multiplicationSign(false) << settings->divisionSign(false) << "^" << ".+" << (QStringLiteral(".") + (settings->printops.use_unicode_signs ? SIGN_MINUS : "-")) << (QStringLiteral(".") + settings->multiplicationSign(false)) << (QStringLiteral(".") + settings->divisionSign(false)) << ".^" << "mod" << "rem" << "//" << "&" << "|" << "<<" << ">>" << "&&" << "||" << "xor" << "=" << SIGN_NOT_EQUAL << "<" << SIGN_LESS_OR_EQUAL << SIGN_GREATER_OR_EQUAL << ">";
 			shortcutActionValueEdit->addItems(citems);
 		} else if(i == SHORTCUT_TYPE_COPY_RESULT) {
 			settings->updateActionValueTexts();
@@ -9634,7 +9634,7 @@ void QalculateWindow::insertFunction(MathFunction *f, QWidget *parent) {
 						if(use_current_result) {
 							if(exact_text.empty()) {
 								Number nr(settings->history_answer.size(), 1, 0);
-								((QLineEdit*) fd->entry[i])->setText(QString("%1(%2)").arg(QString::fromStdString(settings->f_answer->preferredInputName(settings->printops.abbreviate_names, settings->printops.use_unicode_signs, false, false, &can_display_unicode_string_function, (void*) fd->entry[i]).formattedName(TYPE_FUNCTION, true))).arg(QString::fromStdString(print_with_evalops(nr))));
+								((QLineEdit*) fd->entry[i])->setText(QStringLiteral("%1(%2)").arg(QString::fromStdString(settings->f_answer->preferredInputName(settings->printops.abbreviate_names, settings->printops.use_unicode_signs, false, false, &can_display_unicode_string_function, (void*) fd->entry[i]).formattedName(TYPE_FUNCTION, true))).arg(QString::fromStdString(print_with_evalops(nr))));
 							} else {
 								((QLineEdit*) fd->entry[i])->setText(QString::fromStdString(exact_text));
 							}

--- a/src/unitsdialog.cpp
+++ b/src/unitsdialog.cpp
@@ -334,7 +334,7 @@ void UnitsDialog::newClicked() {
 				new QTreeWidgetItem(list.isEmpty() ? categoriesView->topLevelItem(2) : list[0], l);
 			}
 		} else if(u->category() != CALCULATOR->temporaryCategory()) {
-			QList<QTreeWidgetItem*> list = categoriesView->findItems(QString("/") + QString::fromStdString(u->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
+			QList<QTreeWidgetItem*> list = categoriesView->findItems(QStringLiteral("/") + QString::fromStdString(u->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
 			if(list.isEmpty()) {
 				if(selected_category != "All") selected_category = "User items";
 				updateUnits();
@@ -429,7 +429,7 @@ void UnitsDialog::editClicked() {
 				new QTreeWidgetItem(list.isEmpty() ? categoriesView->topLevelItem(2) : list[0], l);
 			}
 		} else if(u->category() != CALCULATOR->temporaryCategory()) {
-			QList<QTreeWidgetItem*> list = categoriesView->findItems(QString("/") + QString::fromStdString(u->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
+			QList<QTreeWidgetItem*> list = categoriesView->findItems(QStringLiteral("/") + QString::fromStdString(u->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
 			if(list.isEmpty()) {
 				if(selected_category != "All") selected_category = "User items";
 				updateUnits();

--- a/src/variablesdialog.cpp
+++ b/src/variablesdialog.cpp
@@ -211,7 +211,7 @@ void VariablesDialog::newVariable(int type) {
 				new QTreeWidgetItem(list.isEmpty() ? categoriesView->topLevelItem(2) : list[0], l);
 			}
 		} else if(v->category() != CALCULATOR->temporaryCategory()) {
-			QList<QTreeWidgetItem*> list = categoriesView->findItems(QString("/") + QString::fromStdString(v->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
+			QList<QTreeWidgetItem*> list = categoriesView->findItems(QStringLiteral("/") + QString::fromStdString(v->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
 			if(list.isEmpty()) {
 				if(selected_category != "All") selected_category = "User items";
 				updateVariables();
@@ -298,7 +298,7 @@ void VariablesDialog::editClicked() {
 				new QTreeWidgetItem(list.isEmpty() ? categoriesView->topLevelItem(2) : list[0], l);
 			}
 		} else if(v->category() != CALCULATOR->temporaryCategory()) {
-			QList<QTreeWidgetItem*> list = categoriesView->findItems(QString("/") + QString::fromStdString(v->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
+			QList<QTreeWidgetItem*> list = categoriesView->findItems(QStringLiteral("/") + QString::fromStdString(v->category()), Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap, 1);
 			if(list.isEmpty()) {
 				if(selected_category != "All") selected_category = "User items";
 				updateVariables();


### PR DESCRIPTION
- Qt provides a macro [`QStringLiteral()`](https://doc.qt.io/qt-6/qstring.html#QStringLiteral), which makes constructing `QString` objects from string literals more efficient.
