### PR TITLE
Fix English translations not used despite being preferred

### DIFF
--- a/qalculate-qt.pro
+++ b/qalculate-qt.pro
@@ -47,7 +47,7 @@ HEADERS += src/calendarconversiondialog.h src/csvdialog.h src/dataseteditdialog.
 
 SOURCES += src/calendarconversiondialog.cpp src/csvdialog.cpp src/dataseteditdialog.cpp src/datasetsdialog.cpp src/expressionedit.cpp src/fpconversiondialog.cpp src/functioneditdialog.cpp src/functionsdialog.cpp src/historyview.cpp src/itemproxymodel.cpp src/keypadwidget.cpp src/main.cpp src/matrixwidget.cpp src/percentagecalculationdialog.cpp src/periodictabledialog.cpp src/plotdialog.cpp src/preferencesdialog.cpp src/qalculateqtsettings.cpp src/qalculatewindow.cpp src/unitsdialog.cpp src/uniteditdialog.cpp src/unknowneditdialog.cpp src/variableeditdialog.cpp src/variablesdialog.cpp
 
-LANGUAGES = ca de es fr nl pt_BR pt_PT ru sl sv zh_CN
+LANGUAGES = ca de en es fr nl pt_BR pt_PT ru sl sv zh_CN
 
 !win32 {
 	#parameters: var, prepend, append
@@ -58,6 +58,7 @@ LANGUAGES = ca de es fr nl pt_BR pt_PT ru sl sv zh_CN
 
 	TRANSLATIONS = 	translations/qalculate-qt_ca.ts \
 			translations/qalculate-qt_de.ts \
+			translations/qalculate-qt_en.ts \
 			translations/qalculate-qt_es.ts \
 			translations/qalculate-qt_fr.ts \
 			translations/qalculate-qt_nl.ts \
@@ -89,6 +90,7 @@ unix:!equals(COMPILE_RESOURCES,"yes"):!android:!macx {
 
 	qm.files = 	translations/qalculate-qt_ca.qm \
 			translations/qalculate-qt_de.qm \
+			translations/qalculate-qt_en.qm \
 			translations/qalculate-qt_es.qm \
 			translations/qalculate-qt_fr.qm \
 			translations/qalculate-qt_nl.qm \

--- a/qalculate-qt.pro
+++ b/qalculate-qt.pro
@@ -49,26 +49,13 @@ SOURCES += src/calendarconversiondialog.cpp src/csvdialog.cpp src/dataseteditdia
 
 LANGUAGES = ca de en es fr nl pt_BR pt_PT ru sl sv zh_CN
 
+#parameters: var, prepend, append
+defineReplace(prependAll) {
+	for(a,$$1):result += $$2$${a}$$3
+	return($$result)
+}
+
 !win32 {
-	#parameters: var, prepend, append
-	defineReplace(prependAll) {
-		for(a,$$1):result += $$2$${a}$$3
-		return($$result)
-	}
-
-	TRANSLATIONS = 	translations/qalculate-qt_ca.ts \
-			translations/qalculate-qt_de.ts \
-			translations/qalculate-qt_en.ts \
-			translations/qalculate-qt_es.ts \
-			translations/qalculate-qt_fr.ts \
-			translations/qalculate-qt_nl.ts \
-			translations/qalculate-qt_pt_BR.ts \
-			translations/qalculate-qt_pt_PT.ts \
-			translations/qalculate-qt_ru.ts \
-			translations/qalculate-qt_sl.ts \
-			translations/qalculate-qt_sv.ts \
-			translations/qalculate-qt_zh_CN.ts
-
 	TRANSLATIONS = $$prependAll(LANGUAGES, $$PWD/translations/qalculate-qt_, .ts)
 	TRANSLATIONS_FILES =
 	qtPrepareTool(LRELEASE, lrelease) for(tsfile, TRANSLATIONS) {
@@ -88,19 +75,7 @@ unix:!equals(COMPILE_RESOURCES,"yes"):!android:!macx {
 
 	target.path = $$BINDIR
 
-	qm.files = 	translations/qalculate-qt_ca.qm \
-			translations/qalculate-qt_de.qm \
-			translations/qalculate-qt_en.qm \
-			translations/qalculate-qt_es.qm \
-			translations/qalculate-qt_fr.qm \
-			translations/qalculate-qt_nl.qm \
-			translations/qalculate-qt_pt_BR.qm \
-			translations/qalculate-qt_pt_PT.qm \
-			translations/qalculate-qt_ru.qm \
-			translations/qalculate-qt_sl.qm \
-			translations/qalculate-qt_sv.qm \
-			translations/qalculate-qt_zh_CN.qm
-		
+	qm.files = $$prependAll(LANGUAGES, $$PWD/translations/qalculate-qt_, .qm)
 	qm.path = $$TRANSLATIONS_DIR
 
 	desktop.files = data/io.github.Qalculate.qalculate-qt.desktop

--- a/translations/qalculate-qt_en.ts
+++ b/translations/qalculate-qt_en.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<!--
+    An empty translation file is required for the base language.
+    If this file is not created, the base language will only be used as a fallback despite it
+    being the preferred language of the user over other supported languages. E.g.
+    $ LANGUAGE=en:nl qalculate-qt
+    will result in Dutch translations being used despite English being higher priority.
+    See https://bugreports.qt.io/browse/QTBUG-69196
+-->
+<TS version="2.1" language="en">
+</TS>


### PR DESCRIPTION
When specifying the preferred language on Linux, the `$LANGUAGE` env var is used. See <https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html>.

**Example:**
`$ LANGUAGE=en:nl qalculate-qt`

**Expected:**
qalculate should be in English as this is a localization that it provides. If English would not be supported, it should fall back to using Dutch (nl).

**Actual:**
qalculate uses Dutch translations.

**Cause:**
If an empty translation file for the base language (here "en") is not provided, the base language is only used as a fallback.
See <https://bugreports.qt.io/browse/QTBUG-69196>

## Simplifying .pro (optional)
I noticed some duplicate content in the .pro file where the `TRANSLATIONS` var has no effect for `.ts` files, it is overwritten by `$$prependAll(LANGUAGES, ...)`. In addition, the qm files are not updated when `LANGUAGES` changes. This leads to four places where a new language needs to be added:
- the actual .ts file
- the `LANGUAGES` var (sets only .ts)
- the .ts `TRANSLATIONS` var (no effect)
- the .qm `TRANSLATIONS` var

After this change, only the translation file needs to be added and the `LANGUAGES` var updated.
This change is not required for the rest of the PR. If it would be preferred to see this change in another PR or not at all, I can drop the commit.

Additional search keywords:
- $LANGUAGE not respected
- Wrong language used